### PR TITLE
Don’t try to make Travis CI upgrade to a newer jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-sudo: false
-addons:
-  apt:
-    packages:
-    - oracle-java8-installer
+#sudo: false
+#addons:
+#  apt:
+#    packages:
+#      - oracle-java8-installer
 language: scala
 jdk:
 - oraclejdk8


### PR DESCRIPTION
Downloading the jdk seems to currently fail. We might temporarily disable that and use the default jdk of Travis CI.