### PR TITLE
newer 2.13 snapshot, 2.12.6, fix language warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@
 language: scala
 scala:
   - 2.11.12
-  - 2.12.5
-  - 2.13.0-pre-b11db01
+  - 2.12.6
+  - 2.13.0-pre-abf21b9
 jdk:
   - oraclejdk8
 env:
@@ -16,12 +16,12 @@ env:
   - SCALAJS_VERSION=1.0.0-M3
 matrix:
   exclude:
-    - scala: 2.13.0-pre-b11db01
+    - scala: 2.13.0-pre-abf21b9
       env: SCALAJS_VERSION=0.6.22
-    - scala: 2.13.0-pre-b11db01
+    - scala: 2.13.0-pre-abf21b9
       env: SCALAJS_VERSION=1.0.0-M3
   include:
-    - scala: 2.12.5
+    - scala: 2.12.6
       env: TEST_SCALAFIX=true
 before_script:
   - ./checkCLA.sh

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ inThisBuild(Def.settings(
   organization := "org.scala-lang",
   version := "0.1-SNAPSHOT",
   resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
-  crossScalaVersions := Seq("2.12.5", "2.13.0-pre-b11db01", "2.11.12"),
+  crossScalaVersions := Seq("2.12.6", "2.13.0-pre-abf21b9", "2.11.12"),
   scalaVersion := crossScalaVersions.value.head,
   scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions")
 ))

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ inThisBuild(Def.settings(
   version := "0.1-SNAPSHOT",
   resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
   crossScalaVersions := Seq("2.12.5", "2.13.0-pre-b11db01", "2.11.12"),
-  scalaVersion := crossScalaVersions.value.head
+  scalaVersion := crossScalaVersions.value.head,
+  scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions")
 ))
 
 lazy val `scala-collection-compat` = crossProject(JSPlatform, JVMPlatform)

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -23,7 +23,7 @@ lazy val input = project
 lazy val output = project
   .settings(
     resolvers += "scala-pr" at "https://scala-ci.typesafe.com/artifactory/scala-integration/",
-    scalaVersion := "2.13.0-M4-pre-20d3c21"
+    scalaVersion := "2.13.0-pre-abf21b9"
   )
 
 lazy val tests = project

--- a/scalafix/output/src/main/scala/fix/StreamSrc.scala
+++ b/scalafix/output/src/main/scala/fix/StreamSrc.scala
@@ -2,7 +2,7 @@ package fix
 
 object StreamSrc {
   val s = LazyList(1, 2, 3)
-  s.lazyAppendAll(List(4, 5, 6))
+  s.lazyAppendedAll(List(4, 5, 6))
   1 #:: 2 #:: 3 #:: LazyList.Empty
   val isEmpty: LazyList[_] => Boolean = {
     case LazyList.Empty => true

--- a/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_NewCollections.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_NewCollections.scala
@@ -103,7 +103,7 @@ case class Scalacollectioncompat_NewCollections(index: SemanticdbIndex)
   def replaceStreamAppend(ctx: RuleCtx): Patch =
     ctx.tree.collect {
       case streamAppend(t: Name) =>
-        ctx.replaceTree(t, "lazyAppendAll")
+        ctx.replaceTree(t, "lazyAppendedAll")
     }.asPatch
 
   override def fix(ctx: RuleCtx): Patch = {

--- a/src/main/scala-2.11_2.12/scala/collection/compat/package.scala
+++ b/src/main/scala-2.11_2.12/scala/collection/compat/package.scala
@@ -45,7 +45,7 @@ package object compat {
   }
 
   implicit class StreamExtensionMethods[A](private val stream: Stream[A]) extends AnyVal {
-    def lazyAppendAll(as: => TraversableOnce[A]): Stream[A] = stream.append(as)
+    def lazyAppendedAll(as: => TraversableOnce[A]): Stream[A] = stream.append(as)
   }
 
   implicit class SortedExtensionMethods[K, T <: Sorted[K, T]](private val fact: Sorted[K, T]) {

--- a/src/test/scala/test/scala/collection/StreamTest.scala
+++ b/src/test/scala/test/scala/collection/StreamTest.scala
@@ -7,9 +7,9 @@ import scala.collection.compat._
 class StreamTest {
 
   @Test
-  def lazyAppendAll(): Unit = {
+  def lazyAppendedAll(): Unit = {
     val s = 1 #:: 2 #:: 3 #:: Stream.Empty
-    s.lazyAppendAll(List(4, 5, 6))
+    s.lazyAppendedAll(List(4, 5, 6))
   }
 
 }


### PR DESCRIPTION
the goal here is to get the project green again in the 2.13 community build.

(the 2.12.6 and language warnings parts are just gravy.)

(despite the branch name, this does not enable fatal warnings, since of course on 2.13 we have deprecation warnings)