### PR TITLE
fix github url

### DIFF
--- a/scalafix/input/src/main/scala/fix/CopyToBufferSrc.scala
+++ b/scalafix/input/src/main/scala/fix/CopyToBufferSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/FoldSrc.scala
+++ b/scalafix/input/src/main/scala/fix/FoldSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/RetainSrc.scala
+++ b/scalafix/input/src/main/scala/fix/RetainSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/StreamSrc.scala
+++ b/scalafix/input/src/main/scala/fix/StreamSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/TraversableSrc.scala
+++ b/scalafix/input/src/main/scala/fix/TraversableSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/input/src/main/scala/fix/TupleNZippedSrc.scala
+++ b/scalafix/input/src/main/scala/fix/TupleNZippedSrc.scala
@@ -1,5 +1,5 @@
 /*
-rule = "scala:fix.Scalacollectioncompat_NewCollections"
+rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 

--- a/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_newcollections.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_newcollections.scala
@@ -5,8 +5,8 @@ import scalafix.syntax._
 import scalafix.util._
 import scala.meta._
 
-case class Scalacollectioncompat_NewCollections(index: SemanticdbIndex)
-  extends SemanticRule(index, "Scalacollectioncompat_NewCollections") {
+case class Scalacollectioncompat_newcollections(index: SemanticdbIndex)
+  extends SemanticRule(index, "Scalacollectioncompat_newcollections") {
 
   def replaceSymbols(ctx: RuleCtx): Patch = {
     ctx.replaceSymbols(


### PR DESCRIPTION
this is a bug introduced in:
https://github.com/scala/scala-collection-compat/commit/d63d4ea724e86c26f37e2095a9886c0a9e6c31d3#diff-04c6e90faac2675aa89e2176d2eec7d8R49

per
https://github.com/scalacenter/scalafix/blob/8490db2edf3ef9aa6291870c04e56fa37ce4537d/scalafix-reflect/src/main/scala/scalafix/internal/reflect/GitHubUrlRule.scala#L33

the url format is github:org/repo/version

we use NewCollections as the version, but it get's lowercased

```
scalafix github:scala/scala-collection-compat/NewCollections
```

gives me

```
error: 404 - not found https://raw.githubusercontent.com/scala/scala-collection-compat/master/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_newcollections.scala
```

workaround

```
scalafix https://raw.githubusercontent.com/scala/scala-collection-compat/master/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_NewCollections.scala
```