### PR TITLE
add "implicit class TraversableOnceExtensionMethods"

### DIFF
--- a/src/main/scala-2.11_2.12/scala/collection/compat/package.scala
+++ b/src/main/scala-2.11_2.12/scala/collection/compat/package.scala
@@ -54,6 +54,10 @@ package object compat {
     def rangeUntil(until: K): T = fact.until(until)
   }
 
+  implicit class TraversableOnceExtensionMethods[A](private val self: TraversableOnce[A]) extends AnyVal {
+    def iterator: Iterator[A] = self.toIterator
+  }
+
   // This really belongs into scala.collection but there's already a package object in scala-library so we can't add to it
   type IterableOnce[+X] = TraversableOnce[X]
   val  IterableOnce     = TraversableOnce

--- a/src/test/scala/test/scala/collection/CollectionTest.scala
+++ b/src/test/scala/test/scala/collection/CollectionTest.scala
@@ -46,4 +46,10 @@ class CollectionTest {
     val mT: Map[Int, String] = m
     assertEquals(Map(1 -> "a", 2 -> "b"), m)
   }
+
+  @Test
+  def testIterator: Unit = {
+    val xs = Iterator(1, 2, 3).iterator.toList
+    assertEquals(List(1, 2, 3), xs)
+  }
 }


### PR DESCRIPTION
I want to avoid deprecation warning in Scala 2.13.x but Scala 2.12 `TraversableOnce` does not have `.iterator` method.

```
Welcome to Scala 2.13.0-M4 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> (Iterator(1) : IterableOnce[Int]).foldLeft(0)(_ + _)
                                         ^
       warning: method foldLeft in class IterableOnceExtensionMethods is deprecated (since 2.13.0): Use .iterator.foldLeft instead of .foldLeft on IterableOnce
res0: Int = 1

scala> (Iterator(1) : IterableOnce[Int]).iterator.foldLeft(0)(_ + _)
res1: Int = 1
```

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_172).
Type in expressions for evaluation. Or try :help.

scala> (Iterator(1) : TraversableOnce[Int]).iterator.foldLeft(0)(_ + _)
<console>:12: error: value iterator is not a member of TraversableOnce[Int]
       (Iterator(1) : TraversableOnce[Int]).iterator.foldLeft(0)(_ + _)
                                            ^
```