### PR TITLE
Rewrite `immutable.Set/Map.+`

### DIFF
--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -6,4 +6,6 @@ package fix
 class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   set + (2, 3)
   map + (2 -> 3, 3 -> 4)
+  (set + (2, 3)).map(x => x)
+  set + (2, 3) - 4
 }

--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -1,0 +1,9 @@
+/*
+rule = "scala:fix.Scalacollectioncompat_newcollections"
+ */
+package fix
+
+class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
+  set + (2, 3)
+  map + (2 -> 3, 3 -> 4)
+}

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -1,0 +1,9 @@
+
+
+
+package fix
+
+class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
+  set + 2 + 3
+  map + (2 -> 3) + (3 -> 4)
+}

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -6,4 +6,6 @@ package fix
 class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   set + 2 + 3
   map + (2 -> 3) + (3 -> 4)
+  (set + 2 + 3).map(x => x)
+  set + 2 + 3 - 4
 }


### PR DESCRIPTION
The `+` operation no longer has an overload accepting multiple values

motivation:
https://github.com/scala/collection-strawman/wiki/FAQ#what-are-the-breaking-changes

2nd row, breaking change