### PR TITLE
Rewrite collection.{Map, Set}.+ and collection.Set.-

### DIFF
--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -3,10 +3,22 @@ rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 
-class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
-  set + (2, 3)
-  map + (2 -> 3, 3 -> 4)
-  (set + (2, 3)).map(x => x)
-  set + (2, 3) - 4
-  map.mapValues(_ + 1)
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class SetMapSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + (2, 3)
+  imap + (2 -> 3, 3 -> 4)
+  (iset + (2, 3)).toString
+  iset + (2, 3) - 4
+  imap.mapValues(_ + 1)
+  iset + 1
+  iset - 2
+  cset + 1
+  cset - 2
+  cmap + (2 -> 3) + ((4, 5))
 }

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -3,10 +3,22 @@
 
 package fix
 
-class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
-  set + 2 + 3
-  map + (2 -> 3) + (3 -> 4)
-  (set + 2 + 3).map(x => x)
-  set + 2 + 3 - 4
-  map.mapValues(_ + 1).toMap
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class SetMapSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + 2 + 3
+  imap + (2 -> 3) + (3 -> 4)
+  (iset + 2 + 3).toString
+  iset + 2 + 3 - 4
+  imap.mapValues(_ + 1).toMap
+  iset + 1
+  iset - 2
+  cset ++ _root_.scala.collection.Set(1)
+  cset -- _root_.scala.collection.Set(2)
+  cmap ++ _root_.scala.collection.Map(2 -> 3) ++ _root_.scala.collection.Map((4, 5))
 }


### PR DESCRIPTION
This is incomplete since, it's blocked by https://github.com/scalameta/scalameta/issues/1212 (Add support to query type of a term)

iset: immutable.Set[Int]
cset: collecion.Set[Int]

both have +/- implemented via SetLike

given

iset + 1
cset + 1

we know that + is from SetLike, but it's not possible to get the type of iset/cset