### PR TITLE
Experimental

### DIFF
--- a/scalafix/input/src/main/scala/fix/ExperimentalSrc.scala
+++ b/scalafix/input/src/main/scala/fix/ExperimentalSrc.scala
@@ -1,0 +1,27 @@
+/*
+rule = "scala:fix.Experimental"
+ */
+package fix
+
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class ExperimentalSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + 1
+  iset - 2
+  cset + 1
+  cset - 2
+  
+  cmap + (2 -> 3)
+  cmap + ((4, 5))
+  imap + (2 -> 3)
+  imap + ((4, 5))
+
+  // Map.zip
+  imap.zip(List())
+  List().zip(List())
+}

--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -3,12 +3,27 @@ rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 
-class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
-  set + (2, 3)
-  map + (2 -> 3, 3 -> 4)
-  (set + (2, 3)).map(x => x)
-  set + (2, 3) - 4
-  map.mapValues(_ + 1)
-  map.zip(List())
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class SetMapSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + (2, 3)
+  imap + (2 -> 3, 3 -> 4)
+  (iset + (2, 3)).toString
+  iset + (2, 3) - 4
+  imap.mapValues(_ + 1)
+  iset + 1
+  iset - 2
+  cset + 1
+  cset - 2
+  cmap + (2 -> 3)
+  cmap + ((4, 5))
+  imap + (2 -> 3)
+  imap + ((4, 5))
+  imap.zip(List())
   List().zip(List())
 }

--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -9,4 +9,5 @@ class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   (set + (2, 3)).map(x => x)
   set + (2, 3) - 4
   map.mapValues(_ + 1)
+  map.zip(List())
 }

--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -3,27 +3,10 @@ rule = "scala:fix.Scalacollectioncompat_newcollections"
  */
 package fix
 
-import scala.collection
-import scala.collection.immutable
-import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
-
-class SetMapSrc(iset: immutable.Set[Int], 
-                cset: collection.Set[Int],
-                imap: immutable.Map[Int, Int],
-                cmap: collection.Map[Int, Int]) {
-  iset + (2, 3)
-  imap + (2 -> 3, 3 -> 4)
-  (iset + (2, 3)).toString
-  iset + (2, 3) - 4
-  imap.mapValues(_ + 1)
-  iset + 1
-  iset - 2
-  cset + 1
-  cset - 2
-  cmap + (2 -> 3)
-  cmap + ((4, 5))
-  imap + (2 -> 3)
-  imap + ((4, 5))
-  imap.zip(List())
-  List().zip(List())
+class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
+  set + (2, 3)
+  map + (2 -> 3, 3 -> 4)
+  (set + (2, 3)).toString
+  set + (2, 3) - 4
+  map.mapValues(_ + 1)
 }

--- a/scalafix/input/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/input/src/main/scala/fix/SetMapSrc.scala
@@ -10,4 +10,5 @@ class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   set + (2, 3) - 4
   map.mapValues(_ + 1)
   map.zip(List())
+  List().zip(List())
 }

--- a/scalafix/output/src/main/scala/fix/ExperimentalSrc.scala
+++ b/scalafix/output/src/main/scala/fix/ExperimentalSrc.scala
@@ -1,0 +1,27 @@
+
+
+
+package fix
+
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class ExperimentalSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + 1
+  iset - 2
+  cset ++ _root_.scala.collection.Set(1)
+  cset -- _root_.scala.collection.Set(2)
+  
+  cmap ++ _root_.scala.collection.Map(2 -> 3)
+  cmap ++ _root_.scala.collection.Map((4, 5))
+  imap + (2 -> 3)
+  imap + ((4, 5))
+
+  // Map.zip
+  imap.zip(List()).toMap
+  List().zip(List())
+}

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -9,4 +9,5 @@ class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   (set + 2 + 3).map(x => x)
   set + 2 + 3 - 4
   map.mapValues(_ + 1).toMap
+  map.zip(List()).toMap
 }

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -3,27 +3,10 @@
 
 package fix
 
-import scala.collection
-import scala.collection.immutable
-import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
-
-class SetMapSrc(iset: immutable.Set[Int], 
-                cset: collection.Set[Int],
-                imap: immutable.Map[Int, Int],
-                cmap: collection.Map[Int, Int]) {
-  iset + 2 + 3
-  imap + (2 -> 3) + (3 -> 4)
-  (iset + 2 + 3).toString
-  iset + 2 + 3 - 4
-  imap.mapValues(_ + 1).toMap
-  iset + 1
-  iset - 2
-  cset ++ _root_.scala.collection.Set(1)
-  cset -- _root_.scala.collection.Set(2)
-  cmap ++ _root_.scala.collection.Map(2 -> 3)
-  cmap ++ _root_.scala.collection.Map((4, 5))
-  imap + (2 -> 3)
-  imap + ((4, 5))
-  imap.zip(List()).toMap
-  List().zip(List())
+class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
+  set + 2 + 3
+  map + (2 -> 3) + (3 -> 4)
+  (set + 2 + 3).toString
+  set + 2 + 3 - 4
+  map.mapValues(_ + 1).toMap
 }

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -10,4 +10,5 @@ class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
   set + 2 + 3 - 4
   map.mapValues(_ + 1).toMap
   map.zip(List()).toMap
+  List().zip(List())
 }

--- a/scalafix/output/src/main/scala/fix/SetMapSrc.scala
+++ b/scalafix/output/src/main/scala/fix/SetMapSrc.scala
@@ -3,12 +3,27 @@
 
 package fix
 
-class SetMapSrc(set: Set[Int], map: Map[Int, Int]) {
-  set + 2 + 3
-  map + (2 -> 3) + (3 -> 4)
-  (set + 2 + 3).map(x => x)
-  set + 2 + 3 - 4
-  map.mapValues(_ + 1).toMap
-  map.zip(List()).toMap
+import scala.collection
+import scala.collection.immutable
+import scala.collection.mutable.{Map, Set} // Challenge to make sure the scoping is correct
+
+class SetMapSrc(iset: immutable.Set[Int], 
+                cset: collection.Set[Int],
+                imap: immutable.Map[Int, Int],
+                cmap: collection.Map[Int, Int]) {
+  iset + 2 + 3
+  imap + (2 -> 3) + (3 -> 4)
+  (iset + 2 + 3).toString
+  iset + 2 + 3 - 4
+  imap.mapValues(_ + 1).toMap
+  iset + 1
+  iset - 2
+  cset ++ _root_.scala.collection.Set(1)
+  cset -- _root_.scala.collection.Set(2)
+  cmap ++ _root_.scala.collection.Map(2 -> 3)
+  cmap ++ _root_.scala.collection.Map((4, 5))
+  imap + (2 -> 3)
+  imap + ((4, 5))
+  imap.zip(List()).toMap
   List().zip(List())
 }

--- a/scalafix/rules/src/main/scala/fix/Experimental.scala
+++ b/scalafix/rules/src/main/scala/fix/Experimental.scala
@@ -1,0 +1,93 @@
+package fix
+
+import scalafix._
+import scalafix.syntax._
+import scalafix.util._
+import scala.meta._
+
+case class Experimental(index: SemanticdbIndex) extends SemanticRule(index, "Experimental") {
+  // WARNING: TOTAL HACK
+  // this is only to unblock us until Term.tpe is available: https://github.com/scalameta/scalameta/issues/1212
+  // if we have a simple identifier, we can look at his definition at query it's type
+  // this should be improved in future version of scalameta
+  object TypeMatcher {
+    def apply(symbols: Symbol*)(implicit index: SemanticdbIndex): TypeMatcher =
+      new TypeMatcher(symbols: _*)(index)
+  }
+
+  final class TypeMatcher(symbols: Symbol*)(implicit index: SemanticdbIndex) {
+    def unapply(tree: Tree): Boolean = {
+      index.denotation(tree)
+           .exists(_.names.headOption.exists(n => symbols.exists(_ == n.symbol)))
+    }
+  }
+
+  val CollectionMap: TypeMatcher = TypeMatcher(
+    Symbol("_root_.scala.collection.immutable.Map#"),
+    Symbol("_root_.scala.collection.mutable.Map#"),
+    Symbol("_root_.scala.Predef.Map#")
+  )
+
+  val CollectionSet: TypeMatcher = TypeMatcher(Symbol("_root_.scala.collection.Set#"))
+
+  val mapZip = 
+    SymbolMatcher.exact(
+      Symbol("_root_.scala.collection.IterableLike#zip(Lscala/collection/GenIterable;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.")
+    )
+
+  val mapPlus = 
+    SymbolMatcher.exact(
+      Symbol("_root_.scala.collection.MapLike#`+`(Lscala/Tuple2;)Lscala/collection/Map;.")
+    )
+
+  val setPlus = 
+    SymbolMatcher.exact(
+      Symbol("_root_.scala.collection.SetLike#`+`(Ljava/lang/Object;)Lscala/collection/Set;.")
+    )
+
+  val setMinus = 
+    SymbolMatcher.exact(
+      Symbol("_root_.scala.collection.SetLike#`-`(Ljava/lang/Object;)Lscala/collection/Set;.")
+    )
+
+  def startsWithParens(tree: Tree): Boolean = 
+    tree.tokens.headOption.map(_.is[Token.LeftParen]).getOrElse(false)
+
+  def replaceMapZip(ctx: RuleCtx): Patch = {
+    ctx.tree.collect {
+      case ap @ Term.Apply(Term.Select(CollectionMap(), mapZip(_)), List(_)) =>
+        ctx.addRight(ap, ".toMap")
+    }.asPatch
+  }
+
+  def replaceSetMapPlusMinus(ctx: RuleCtx): Patch = {
+    def rewriteOp(op: Tree, rhs: Tree, doubleOp: String, col0: String): Patch = {
+      val col = "_root_.scala.collection." + col0
+      val callSite =
+        if (startsWithParens(rhs)) {
+          ctx.addLeft(rhs, col)          
+        }
+        else {
+          ctx.addLeft(rhs, col + "(") +
+          ctx.addRight(rhs, ")")
+        }
+
+      ctx.addRight(op, doubleOp) + callSite
+    }
+
+    ctx.tree.collect {
+      case Term.ApplyInfix(CollectionSet(), op @ setPlus(_), Nil, List(rhs)) =>
+        rewriteOp(op, rhs, "+", "Set")
+        
+      case Term.ApplyInfix(CollectionSet(), op @ setMinus(_), Nil, List(rhs)) =>
+        rewriteOp(op, rhs, "-", "Set")
+
+      case Term.ApplyInfix(_, op @ mapPlus(_), Nil, List(rhs)) =>
+        rewriteOp(op, rhs, "+", "Map")
+    }.asPatch
+  }
+
+  override def fix(ctx: RuleCtx): Patch =
+    replaceSetMapPlusMinus(ctx) +
+    replaceMapZip(ctx)
+}

--- a/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_newcollections.scala
+++ b/scalafix/rules/src/main/scala/fix/Scalacollectioncompat_newcollections.scala
@@ -27,6 +27,8 @@ case class Scalacollectioncompat_newcollections(index: SemanticdbIndex)
     } yield (open, close)
 
   // terms dont give us terms https://github.com/scalameta/scalameta/issues/1212
+  // WARNING: TOTAL HACK
+  // this is only to unblock us until Term.tpe is available: https://github.com/scalameta/scalameta/issues/1212
   // if we have a simple identifier, we can look at his definition at query it's type
   // this should be improved in future version of scalameta
   object TypeMatcher {
@@ -37,8 +39,7 @@ case class Scalacollectioncompat_newcollections(index: SemanticdbIndex)
   final class TypeMatcher(symbols: Symbol*)(implicit index: SemanticdbIndex) {
     def unapply(tree: Tree): Boolean = {
       index.denotation(tree)
-           .map(_.names.headOption.exists(n => symbols.exists(_ == n.symbol)))
-           .getOrElse(false)
+           .exists(_.names.headOption.exists(n => symbols.exists(_ == n.symbol)))
     }
   }
 


### PR DESCRIPTION
superseded: https://github.com/scala/scala-collection-compat/pull/62 and https://github.com/scala/scala-collection-compat/pull/58