### PR TITLE
Add helper traits to provide 2.13 syntax for 2.12 collections

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val compat = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(scalaModuleSettingsJVM)
   .settings(
     name := "scala-collection-compat",
-    version := "0.1-SNAPSHOT",
+    version := "0.2.1+proxy",
     scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions"),
     unmanagedSourceDirectories in Compile += {
       val sharedSourceDir = baseDirectory.value.getParentFile / "src/main"

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/Proxy.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/Proxy.scala
@@ -1,0 +1,47 @@
+package scala.collection.compat
+
+import scala.collection.GenTraversableLike
+import scala.collection.generic
+import scala.collection.{immutable => cimmutable}
+
+// Provide 2.13 syntax for 2.12 collections
+
+trait GrowableProxy[-A] { _: generic.Growable[A] =>
+  def addOne(elem: A): this.type
+  @`inline` override final def += (elem: A): this.type = addOne(elem)
+}
+
+trait ShrinkableProxy[-A] { _: generic.Shrinkable[A] =>
+  def subtractOne(elem: A): this.type
+  @`inline` override final def -= (elem: A): this.type = subtractOne(elem)
+}
+
+trait ClassNameProxy { _: GenTraversableLike[_, _] =>
+  def className: String
+  override def stringPrefix: String = className
+}
+
+trait ImmutableSetProxy[A] { _: cimmutable.Set[A] =>
+  def excl(elem: A): cimmutable.Set[A]
+  @`inline` final def - (elem: A): cimmutable.Set[A] = excl(elem)
+
+  def incl(elem: A): cimmutable.Set[A]
+  @`inline` def + (elem: A): cimmutable.Set[A] = incl(elem)
+}
+
+trait ImmutableMapProxy[A, B] { _: cimmutable.Map[A, B] =>
+  def remove(key: A): cimmutable.Map[A, B]
+  @`inline` final def - (key: A): cimmutable.Map[A, B] = remove(key)
+
+  def updated[B1 >: B](key: A, value: B1): cimmutable.Map[A, B1]
+  override def + [B1 >: B](kv: (A, B1)): cimmutable.Map[A, B1] = updated(kv._1, kv._2)
+}
+
+trait MapOps[A, B] {
+  def filterInPlace(p: ((A, B)) => Boolean): this.type
+}
+
+trait SetOps[A] {
+  def filterInPlace(p: A ⇒ Boolean): this.type
+  def addOne(elem: A): this.type
+}


### PR DESCRIPTION
For example:

build.sbt

```scala
unmanagedSourceDirectories in Compile += {
  val sourceDir = (sourceDirectory in Compile).value
  CrossVersion.partialVersion(scalaVersion.value) match {
    case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
    case _                       => sourceDir / "scala-2.13-"
  }
}
```

`src/main/scala/MyGrowable.scala`

```scala
import scala.collection.mutable

class MyGrowable[A](a: mutable.Set[A]) extends MyGrowableTemplate[A] {
  def addOne(elem: A): this.type = a += elem
}

```

`src/main/scala-2.13+/CompatMyGrowable.scala`

```scala
import scala.collection.mutable

trait MyGrowableTemplate[A] extends mutable.Growable[A] // addOne / + are already available
```

`src/main/scala-2.13-/CompatMyGrowable.scala`

```scala
import scala.collection.{generic, compat}

trait MyGrowableTemplate[A] extends generic.Growable[A] with compat.GrowableProxy[A]
```