### PR TITLE
Don't use bundle to publish scalafix rules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,9 +50,8 @@ lazy val compatJS  = compat.js
 
 lazy val scalafixRules = project
   .in(file("scalafix/rules"))
-  .settings(scalaModuleSettings)
-  .settings(scalaModuleSettingsJVM)
   .settings(
+    organization := (organization in compatJVM).value,
     name := "scala-collection-migrations",
     scalaVersion := scalafixScala212,
     libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % scalafixVersion


### PR DESCRIPTION
This PR is to make my scalafix hack possible: https://github.com/MasseGuillaume/scalafix/commit/4108726c5239a584c440753fea9152b6d7467667

It's not possible to use bundles to fetch the migration rule for some reason. It's probably going to be useful when we have scalafix 0.6.X.