### PR TITLE
Rewrite xs.to => xs.to(CC) (fix #106)

### DIFF
--- a/scalafix/input/src/main/scala/fix/TraversableSrc.scala
+++ b/scalafix/input/src/main/scala/fix/TraversableSrc.scala
@@ -14,5 +14,5 @@ object TraversableSrc {
   def m1(xs: Traversable[Int]): List[Int] =
     xs.to
 
-  def m2(xs: Traversable[Int]): List[Int] = xs.to
+  List[Int]() // unrelated matching brackets
 }

--- a/scalafix/output212/src/main/scala/fix/TraversableSrc.scala
+++ b/scalafix/output212/src/main/scala/fix/TraversableSrc.scala
@@ -13,7 +13,7 @@ object TraversableSrc {
   }
 
   def m1(xs: Iterable[Int]): List[Int] =
-    xs.to
+    xs.to(scala.collection.immutable.List)
 
-  def m2(xs: Iterable[Int]): List[Int] = xs.to
+  List[Int]() // unrelated matching brackets
 }

--- a/scalafix/tests/src/test/scala/fix/ScalafixTests.scala
+++ b/scalafix/tests/src/test/scala/fix/ScalafixTests.scala
@@ -17,5 +17,5 @@ class ScalafixTests
 
   runAllTests()
   // to run only one test:
-  // testsToRun.filter(_.filename.toNIO.getFileName.toString == "IterableSrc.scala" ).foreach(runOn)
+  // testsToRun.filter(_.filename.toNIO.getFileName.toString == "Playground.scala" ).foreach(runOn)
 }


### PR DESCRIPTION
For example: https://github.com/akka/akka/blob/9fae4e283947c956e43aa37f83156f0e728b5965/akka-actor/src/main/scala/akka/io/Udp.scala#L282-L283