### PR TITLE
fix regression in artifact naming

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform)("compat",
   .jvmSettings(scalaModuleSettingsJVM)
   .settings(
     name := "scala-collection-compat",
+    moduleName := "scala-collection-compat",
     version := "0.2.0-SNAPSHOT",
     scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions"),
     unmanagedSourceDirectories in Compile += {


### PR DESCRIPTION
recent build changes caused "compat.jar" to be published instead of
"scala-collection-compat.jar" like before. this fixes it

caught by the Scala 2.12 community build