### PR TITLE
Add caching for sbt-launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ script:
 
 cache:
   directories:
+  - "$HOME/.sbt/preloaded"
   - "$HOME/.sbt/0.13/dependency"
   - "$HOME/.sbt/boot/scala*"
   - "$HOME/.sbt/launchers"


### PR DESCRIPTION
I notice that the ci fetch sbt every time: 
https://travis-ci.org/scala/scala-collection-compat/jobs/411677832#L570