### PR TITLE
fix the "Factory" type alias definition

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -16,7 +16,7 @@ private[compat] trait PackageShared {
    * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
    * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
    */
-  type Factory[-A, +C] <: CanBuildFrom[Nothing, A, C] // Ideally, this would be an opaque type
+  type Factory[-A, +C] = CanBuildFrom[Nothing, A, C] // Ideally, this would be an opaque type
 
   implicit class FactoryOps[-A, +C](private val factory: Factory[A, C]) {
 

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -16,7 +16,7 @@ private[compat] trait PackageShared {
    * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
    * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
    */
-  type Factory[-A, +C] = CanBuildFrom[Nothing, A, C] // Ideally, this would be an opaque type
+  type Factory[-A, +C] = CanBuildFrom[Nothing, A, C]
 
   implicit class FactoryOps[-A, +C](private val factory: Factory[A, C]) {
 
@@ -31,13 +31,6 @@ private[compat] trait PackageShared {
      * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
     def newBuilder: m.Builder[A, C] = factory()
   }
-
-  implicit def fromCanBuildFrom[A, C](implicit cbf: CanBuildFrom[Nothing, A, C]): Factory[A, C] =
-    cbf.asInstanceOf[Factory[A, C]]
-
-  implicit def fromCanBuildFromConversion[X, A, C](x: X)(
-      implicit toCanBuildFrom: X => CanBuildFrom[Nothing, A, C]): Factory[A, C] =
-    fromCanBuildFrom(toCanBuildFrom(x))
 
   implicit def genericCompanionToCBF[A, CC[X] <: GenTraversable[X]](
       fact: GenericCompanion[CC]): CanBuildFrom[Any, A, CC[A]] =

--- a/compat/src/test/scala/test/scala/collection/NoImportTest.scala
+++ b/compat/src/test/scala/test/scala/collection/NoImportTest.scala
@@ -1,0 +1,16 @@
+package test.scala.collection
+
+// Don't import scala.collection.compat._
+import scala.collection.compat.Factory
+import scala.collection.{mutable, immutable}
+
+class NoImportTest {
+
+  implicitly[Factory[Int, List[Int]]]
+  implicitly[Factory[Char, String]]
+  implicitly[Factory[Char, Array[Char]]]
+  implicitly[Factory[Int, collection.BitSet]]
+  implicitly[Factory[Int, mutable.BitSet]]
+  implicitly[Factory[Int, immutable.BitSet]]
+
+}


### PR DESCRIPTION
avoid `import scala.collection.compat._` everywhere in Scala 2.12 and 2.11

### collection-compat v0.2.0

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> implicitly[scala.collection.compat.Factory[Int, List[Int]]]
<console>:12: error: could not find implicit value for parameter e: collection.compat.Factory[Int,List[Int]]
       implicitly[scala.collection.compat.Factory[Int, List[Int]]]
                 ^

scala> import scala.collection.compat._
import scala.collection.compat._

scala> implicitly[scala.collection.compat.Factory[Int, List[Int]]]
res1: collection.compat.Factory[Int,List[Int]] = scala.collection.generic.GenTraversableFactory$$anon$1@41b12185
```

### collection-compat v0.1.1

```
Welcome to Scala 2.12.6 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_181).
Type in expressions for evaluation. Or try :help.

scala> implicitly[scala.collection.compat.Factory[Int, List[Int]]]
res0: scala.collection.compat.Factory[Int,List[Int]] = scala.collection.compat.Factory$$anon$1@33600943
```