### PR TITLE
fix sbt task name in migration tool doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 
 ```bash
 // sbt shell
-> ;test:scalafix Collections213CrossCompat ;scalafix Collections213CrossCompat
+> ;test:scalafix Collection213CrossCompat ;scalafix Collection213CrossCompat
 ```
 
 ### Build.scala


### PR DESCRIPTION
I tried the 0.2.1 migration tool and Collection213CrossCompat appears to be the right name