### PR TITLE
Add "in ThisBuild" to find scalafixDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The `Collection213Upgrade` rewrite upgrades to the 2.13 collections without the 
 
 ```scala
 // build.sbt
-scalafixDependencies += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.1"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.1"
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
 
@@ -70,7 +70,7 @@ To cross-build for 2.12 and 2.11, the rewrite rule introduces a dependency on th
 
 ```scala
 // build.sbt
-scalafixDependencies += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.1"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.1"
 libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "0.2.1"
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```


### PR DESCRIPTION
otherwise for some sbt configurations sbt-scalafix will not pick up the additional rules.