### PR TITLE
[DON'T MERGE] Replace lengthCompare with sizeCompare

### DIFF
--- a/scalafix/input/src/main/scala/fix/LengthCompare213.scala
+++ b/scalafix/input/src/main/scala/fix/LengthCompare213.scala
@@ -1,0 +1,15 @@
+/*
+rule = "Collection213Upgrade"
+ */
+package fix
+
+import scala.collection.Seq
+
+class LengthCompare213(xs: Seq[Int]) {
+  xs.lengthCompare(2) < 0
+  xs lengthCompare 4 match {
+    case 0          => "same"
+    case i if i < 0 => "less"
+    case i if i > 0 => "more"
+  }
+}

--- a/scalafix/output213/src/main/scala/fix/LengthCompare213.scala
+++ b/scalafix/output213/src/main/scala/fix/LengthCompare213.scala
@@ -1,0 +1,12 @@
+package fix
+
+import scala.collection.Seq
+
+class LengthCompare213(xs: Seq[Int]) {
+  xs.sizeCompare(2) < 0
+  xs sizeCompare 4 match {
+    case 0          => "same"
+    case i if i < 0 => "less"
+    case i if i > 0 => "more"
+  }
+}

--- a/scalafix/rules/src/main/scala/scala/fix/collection/Collection213Upgrade.scala
+++ b/scalafix/rules/src/main/scala/scala/fix/collection/Collection213Upgrade.scala
@@ -43,6 +43,9 @@ case class Collection213UpgradeV0(index: SemanticdbIndex)
   val retainSet = normalized(
     "scala/collection/mutable/SetLike#retain()."
   )
+  val lengthCompareSeq = normalized(
+    "scala/collection/SeqLike#lengthCompare()."
+  )
 
   // == Rules ==
 
@@ -51,6 +54,13 @@ case class Collection213UpgradeV0(index: SemanticdbIndex)
       "scala.TraversableOnce"            -> "scala.IterableOnce",
       "scala.collection.TraversableOnce" -> "scala.collection.IterableOnce"
     )
+  }
+
+  def replaceCollectionSeq(ctx: RuleCtx): Patch = {
+    ctx.tree.collect {
+      case lengthCompareSeq(n: Name) =>
+        ctx.replaceTree(n, "sizeCompare")
+    }.asPatch
   }
 
   def replaceMutableSet(ctx: RuleCtx): Patch = {
@@ -121,6 +131,7 @@ case class Collection213UpgradeV0(index: SemanticdbIndex)
       replaceSymbols(ctx) +
       replaceTupleZipped(ctx) +
       replaceMutableMap(ctx) +
-      replaceMutableSet(ctx)
+      replaceMutableSet(ctx) +
+      replaceCollectionSeq(ctx)
   }
 }


### PR DESCRIPTION
Add logic to Collection213Upgrade to replace
`Seq#lengthCompare` with `Seq#sizeCompare`.

Migration to accompany deprecation of `lengthCompare` as proposed in scala/bug#11388.