### PR TITLE
Add tests for #137 and #183

### DIFF
--- a/compat/src/test/scala/test/scala/collection/FactoryTest.scala
+++ b/compat/src/test/scala/test/scala/collection/FactoryTest.scala
@@ -24,6 +24,9 @@ class FactoryTest {
   implicitly[Factory[Int, collection.BitSet]]
   implicitly[Factory[Int, mutable.BitSet]]
   implicitly[Factory[Int, immutable.BitSet]]
+  implicitly[Factory[Nothing, Seq[Nothing]]]
+
+  def f[A] = implicitly[Factory[A, Stream[A]]]
 
   BitSet: Factory[Int, BitSet]
   Iterable: Factory[Int, Iterable[Int]]


### PR DESCRIPTION
I don’t know what changed since these tickets were opened but both
cases work fine now.

Closes https://github.com/scala/scala-collection-compat/issues/137 and https://github.com/scala/scala-collection-compat/issues/183