### PR TITLE
Backport immutable.ArraySeq bug fixes from Scala 2.13

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -113,8 +113,8 @@ object ArraySeq {
     override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofRef[_] =>
-        Arrays.equals(unsafeArray.asInstanceOf[Array[AnyRef]],
-                      that.unsafeArray.asInstanceOf[Array[AnyRef]])
+        arrayEquals(unsafeArray.asInstanceOf[Array[AnyRef]],
+                    that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
   }
@@ -125,7 +125,7 @@ object ArraySeq {
     def length: Int             = unsafeArray.length
     def apply(index: Int): Byte = unsafeArray(index)
     def update(index: Int, elem: Byte) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.bytesHash(unsafeArray, MurmurHash3.seqSeed)
+    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -236,5 +236,21 @@ object ArraySeq {
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _            => super.equals(that)
     }
+  }
+
+  private[this] def arrayEquals(xs: Array[AnyRef], ys: Array[AnyRef]): Boolean = {
+    if (xs eq ys)
+      return true
+    if (xs.length != ys.length)
+      return false
+
+    val len = xs.length
+    var i = 0
+    while (i < len) {
+      if (xs(i) != ys(i))
+        return false
+      i += 1
+    }
+    true
   }
 }


### PR DESCRIPTION
- ArraySeq.ofByte.hashCode from https://github.com/scala/scala/commit/b7523eba5cc8ddf85f05b8c93a077d012fa631db#diff-a7ab156ecfe37114bc259ba947342e46
- ArraySeq.ofRef.equals from https://github.com/scala/scala/commit/3deb1a83f037a47cc4607005d01318a1475a5ba3#diff-a7ab156ecfe37114bc259ba947342e46