### PR TITLE
Update for Scala 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: scala
 scala:
   - 2.11.12
   - 2.12.8
-  - 2.13.0-M5
+  - 2.13.0-RC1
 jdk:
   - oraclejdk8
   - openjdk11
@@ -18,8 +18,8 @@ env:
     - secure: "m0Fw/eH7RXJJoBTfqV6CMd7kaIN2pRPnQPNXJGb546UjqYAlYTkfjvVrWpsgpisRBptI1FEHn24yGbgAHjIes/4un/O62K66I0BffL8PbdeHeNcDjSrTesKEqage2mQfGOiqccVsmkgiKeXNYL8tPZRmPQQ3XZ97mS1SXWlqAJSMW6HfNnvqW14Gdb/snR6I8lQ2o5tRnLerWPnI96pp+xjZca2lD4XDvH2wLJXXLmYY61e23ZYzZMepxBxhGa7js3YTYzCWNrOfBLjFJ5nwRxbjR0WMuz5z5Gdy715WtguKS4Fffd/GJHycLROBU9LCAQDMTxMFvqzFqVFpfq0BuTmmkXFXj+a7dO+ABG0RfoDfoMjn7pHwyHNCZyMMuR1HCjMkbGFwC+Zme2UAYNivtcsuWWeMuypwjyqjfFfNns4FHJ0SXFtC/6+OJkAuUdbEJKReYWKWEsP5SnCH/8PLlc+uUl3tjQkFLc1sOAyx9cTWyBErwuJXhgTrjT9AWvO+fvhcm8z/p5+aaF/U9GIrzPqziX4hGjzc/WC+rsFJSiBDlFQl7br+m8WWs7/wuXqPGXmhf0BNQViDi7fZndDHcY3p3T0An05d/IMKjCUrgLDlJi6VYs9XN7S8ay6MH+XTwIsJGSxtGjfEO4rHGIjtR2GRr8TqdNfnpsI3ucbia1Y="
   matrix:
     - SCALAJS_VERSION=
-    - SCALAJS_VERSION=0.6.26
-    - SCALAJS_VERSION=1.0.0-M6
+    - SCALAJS_VERSION=0.6.27
+    - SCALAJS_VERSION=1.0.0-M7
 
 matrix:
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This library provides some of the new APIs from Scala 2.13 to Scala 2.11 and 2.1
 To use this library, add the following to your build.sbt:
 
 ```
-libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "0.2.2"
+libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
 ```
 
-Version 0.2.2 is compatible with Scala 2.13.0-M5. For Scala 2.13.0-M4 you should use version 0.1.1.
+Version 1.0.0 is compatible with Scala 2.13.0-RC1, 2.12 and 2.11.
 
 Note that there are multiple ways to cross-build projects, see https://github.com/scala/collection-strawman/wiki/FAQ#how-do-i-cross-build-my-project-against-scala-212-and-scala-213.
 
-Also note that this library has not fully stabilized yet. We expect that new, binary incompatible releases of this library will be published (for 2.11, 2.12) until Scala 2.13 is getting close to its final state. Therefore you might want to avoid adding a dependency on that library to your 2.11 / 2.12 artifacts for the time being.
+Starting with version 1.0.0 backwards binary compatibility is enforced within each major version (i.e. anything prior to 2.0.0 will be compatible).
 
 
 The 2.13 collections are mostly backwards compatible, but there are some exceptions. For example, the `to` method is used with a type parameter in 2.12:
@@ -52,7 +52,7 @@ The `Collection213Upgrade` rewrite upgrades to the 2.13 collections without the 
 
 ```scala
 // build.sbt
-scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.2"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "1.0.0"
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
 
@@ -70,8 +70,8 @@ To cross-build for 2.12 and 2.11, the rewrite rule introduces a dependency on th
 
 ```scala
 // build.sbt
-scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "0.2.2"
-libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "0.2.2"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "1.0.0"
+libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "1.0.0"
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -62,7 +62,7 @@ without generating a new key.
   1. The release will be published using the Scala and JVM version combinations specified
      in the travis build matrix where `[ "$RELEASE_COMBO" = "true" ]`.
      - If you need to release against a different Scala version, create a new commit that modifies
-       `.travis.yml` and push a new tag, e.g., `v1.2.3#2.13.0-M5`. The suffix after `#` is ignored.
+       `.travis.yml` and push a new tag, e.g., `v1.2.3#2.13.0-RC1`. The suffix after `#` is ignored.
   1. Travis CI will schedule a build for this release. Review the build logs.
   1. Log into https://oss.sonatype.org/ and identify the staging repository.
   1. Sanity check its contents.

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val junit = libraryDependencies += "com.novocode" % "junit-interface" % "0.
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.8"
-lazy val scala213 = "2.13.0-M5"
+lazy val scala213 = "2.13.0-RC1"
 
 scalaVersionsByJvm in ThisBuild := {
   val all = List(scala211, scala212, scala213)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -5,7 +5,7 @@ case class Version(major: Int, minor: Int, patch: Int) {
 
 object Version {
   private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)".r
-  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)-M([0-9]+)".r
+  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.+)".r
   private val versionRegex2 = "([0-9]+)\\.([0-9]+)".r
   private val versionRegex3 = "([0-9]+)".r
   def parse(raw: String): Option[Version] = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.26")
+val scalaJSVersion = Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("0.6.27")
 
 addSbtPlugin("org.scala-js"           % "sbt-scalajs"              % scalaJSVersion)
 addSbtPlugin("org.portable-scala"     % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
- Stubs are now built for 2.13.0-RC1 and 2.13.0-M5
- Add ScalaJS version 1.0.0-M7
- Update scala-collection-compat version to 1.0.0 and document binary
  compatibility policy in the README