### PR TITLE
allow republishing for new Scala versions

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,19 +4,20 @@ case class Version(major: Int, minor: Int, patch: Int) {
 }
 
 object Version {
-  private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)".r
-  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.+)".r
-  private val versionRegex2 = "([0-9]+)\\.([0-9]+)".r
-  private val versionRegex3 = "([0-9]+)".r
+  // the (#.+)? part allows republishing for a new Scala version
+  private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)(#.+)?".r
+  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.+)(#.+)?".r
+  private val versionRegex2 = "([0-9]+)\\.([0-9]+)(#.+)?".r
+  private val versionRegex3 = "([0-9]+)(#.+)?".r
   def parse(raw: String): Option[Version] = {
     raw match {
-      case versionRegex0(major, minor, patch) =>
+      case versionRegex0(major, minor, patch, _) =>
         Some(Version(major.toInt, minor.toInt, patch.toInt))
-      case versionRegex1(major, minor, patch, _) =>
+      case versionRegex1(major, minor, patch, _, _) =>
         Some(Version(major.toInt, minor.toInt, patch.toInt))
-      case versionRegex2(major, minor) =>
+      case versionRegex2(major, minor, _) =>
         Some(Version(major.toInt, minor.toInt, 0))
-      case versionRegex3(major) =>
+      case versionRegex3(major, _) =>
         Some(Version(major.toInt, 0, 0))
       case _ =>
         None


### PR DESCRIPTION
by ignoring trailing `#junk` on TRAVIS_TAG

context is #210