### PR TITLE
Added AbstractBuilder & AbstractFactory cross-compatible base traits

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/AbstractBuilder.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/AbstractBuilder.scala
@@ -1,0 +1,9 @@
+package scala.collection.compat
+
+import scala.collection.mutable
+
+trait AbstractBuilder[-Elem, +To] extends mutable.Builder[Elem, To] {
+  def addOne(elem: Elem): this.type
+
+  final def +=(elem: Elem): this.type = addOne(elem)
+}

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/AbstractFactory.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/AbstractFactory.scala
@@ -1,0 +1,11 @@
+package scala.collection.compat
+
+import scala.collection.mutable
+
+trait AbstractFactory[-A, +C] extends Factory[A, C] {
+  def fromSpecific(it: IterableOnce[A]): C
+  def newBuilder: mutable.Builder[A, C]
+
+  final def apply(from: Nothing): mutable.Builder[A, C] = newBuilder
+  final def apply(): mutable.Builder[A, C] = newBuilder
+}

--- a/compat/src/main/scala-2.13/scala/collection/compat/package.scala
+++ b/compat/src/main/scala-2.13/scala/collection/compat/package.scala
@@ -21,4 +21,7 @@ package object compat {
 
   type IterableOnce[+X] = scala.collection.IterableOnce[X]
   val IterableOnce = scala.collection.IterableOnce
+
+  type AbstractBuilder[-Elem, +To] = mutable.Builder[Elem, To]
+  type AbstractFactory[-A, +C] = Factory[A, C]
 }


### PR DESCRIPTION
Currently there is no way to implement a `Builder` or `Factory` in a way that would compile in both Scala 2.12 and 2.13. This PR introduces `AbstractBuilder` and `AbstractFactory` which serve that purpose.

This PR is very draft, I just wanted to start a discussion about whether it's a good idea or not.