### PR TITLE
Fix OSGI exports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform)(
       }
     )
     .jvmSettings(
-      OsgiKeys.exportPackage := Seq(s"scala.collection.compat.*;version=${version.value}"),
+      OsgiKeys.exportPackage := Seq(s"scala.collection.compat.*;scala.jdk.*;version=${version.value}"),
       junit
     )
     .jsSettings(


### PR DESCRIPTION
Fix OSGI exports so `scala/jdk` classfiles are not removed
from the jar.

Fixes #224.