### PR TITLE
Add implicit: genericOrderedCompanionToCBF

### DIFF
--- a/compat/src/main/scala-2.11/scala/collection/compat/package.scala
+++ b/compat/src/main/scala-2.11/scala/collection/compat/package.scala
@@ -12,10 +12,15 @@
 
 package scala.collection
 
-import scala.collection.generic.IsTraversableLike
+import scala.collection.generic.{CanBuildFrom, GenericOrderedCompanion, IsTraversableLike}
 import scala.{collection => c}
 
 package object compat extends compat.PackageShared {
+  implicit def genericOrderedCompanionToCBF[A, CC[X] <: Traversable[X]](
+      fact: GenericOrderedCompanion[CC])(
+      implicit ordering: Ordering[A]): CanBuildFrom[Any, A, CC[A]] =
+    CompatImpl.simpleCBF(fact.newBuilder[A])
+
   implicit def toTraversableLikeExtensionMethods[Repr](self: Repr)(
       implicit traversable: IsTraversableLike[Repr])
     : TraversableLikeExtensionMethods[traversable.A, Repr] =

--- a/compat/src/main/scala-2.12/scala/collection/compat/package.scala
+++ b/compat/src/main/scala-2.12/scala/collection/compat/package.scala
@@ -12,7 +12,7 @@
 
 package scala.collection
 
-import scala.collection.generic.IsTraversableLike
+import scala.collection.generic.{CanBuildFrom, GenericOrderedCompanion, IsTraversableLike}
 import scala.{collection => c}
 import scala.collection.{mutable => m}
 
@@ -26,6 +26,11 @@ package object compat extends compat.PackageShared {
     def from[K: Ordering, V](source: TraversableOnce[(K, V)]): m.SortedMap[K, V] =
       build(m.SortedMap.newBuilder[K, V], source)
   }
+
+  implicit def genericOrderedCompanionToCBF[A, CC[X] <: Traversable[X]](
+      fact: GenericOrderedCompanion[CC])(
+      implicit ordering: Ordering[A]): CanBuildFrom[Any, A, CC[A]] =
+    CompatImpl.simpleCBF(fact.newBuilder[A])
 
   implicit def toTraversableLikeExtensionMethods[Repr](self: Repr)(
       implicit traversable: IsTraversableLike[Repr])

--- a/compat/src/test/scala/test/scala/collection/CollectionTest.scala
+++ b/compat/src/test/scala/test/scala/collection/CollectionTest.scala
@@ -17,6 +17,7 @@ import org.junit.Test
 
 import scala.collection.compat._
 import scala.collection.immutable.BitSet
+import scala.collection.mutable.PriorityQueue
 import scala.collection.LinearSeq
 
 class CollectionTest {
@@ -34,6 +35,10 @@ class CollectionTest {
     val b          = xs.to(BitSet) // we can fake a type constructor for the 2 standard BitSet types
     val bT: BitSet = b
     assertEquals(BitSet(1, 2, 3), b)
+
+    val c          = xs.to(PriorityQueue)
+    val cT: PriorityQueue[Int]  = c
+    assert(PriorityQueue(1, 2, 3) sameElements c)
 
     val ys = List(1 -> "a", 2 -> "b")
     val m  = ys.to(Map)


### PR DESCRIPTION
fixes #247 

I don't know If I'm doing things right here... Help is appreciated. 

Please review the new `implicit def`
What needs to be written in the test?
What needs to be done regarding binary compatibility?