### PR TITLE
Fix migration tool installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The migration rules use scalafix. Please see the [official installation instruct
 
 ```scala
 // project/plugins.sbt
-
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.8")
 ```
 
@@ -54,6 +53,7 @@ The `Collection213Upgrade` rewrite upgrades to the 2.13 collections without the 
 ```scala
 // build.sbt
 scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.1"
+addCompilerPlugin(scalafixSemanticdb)
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
 
@@ -71,8 +71,9 @@ To cross-build for 2.12 and 2.11, the rewrite rule introduces a dependency on th
 
 ```scala
 // build.sbt
-scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.2"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.1"
 libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
+addCompilerPlugin(scalafixSemanticdb)
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
 


### PR DESCRIPTION
Fixes #245. 

As `scala-collection-migrations` was not a part of the 2.1.2 release, this PR removes all mention of a 2.1.2 version of `scala-collection-migrations` in the README. Instead, it updates installation instructions to 2.1.1, which I suppose is the only way to mitigate the issue raised in #245.

This PR is related to #264, which fixed the instructions for the `Collection213Upgrade` rewrite, but not for the `Collection213CrossCompat` rewrite. 

I also added a line with `addCompilerPlugin(scalafixSemanticdb)`. The scalafix instructions mandate using this, but the instructions here don't contain the line. While the README does say to follow the installation instructions in scalafix, I think it makes for a better user experience to outline the steps here too.

With these updated instructions, I was able to run the migration rules without errors on my project.