### PR TITLE
Prepare for working on version 3.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
                                                  |See the NOTICE file distributed with this work for
                                                  |additional information regarding copyright ownership.
                                                  |""".stripMargin)),
-  scalaModuleMimaPreviousVersion := Some("2.1.3")
+  scalaModuleMimaPreviousVersion := None // TODO Change to `Some("3.0.0")` after it is released
 )
 
 lazy val root = project

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -19,7 +19,7 @@ import scala.collection.{immutable => i, mutable => m}
 import scala.{collection => c}
 
 /** The collection compatibility API */
-private[compat] trait PackageShared {
+private[compat] class PackageShared {
   import CompatImpl._
 
   /**


### PR DESCRIPTION
- Disable MiMa checks
- Turn `trait PackageShared` into a `class`, so that we can later add methods without breaking binary compatibility.