### PR TITLE
Refer to version 2.1.4 instead of 2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides some of the new APIs from Scala 2.13 to Scala 2.11 and 2.1
 To use this library, add the following to your build.sbt:
 
 ```
-libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3"
+libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4"
 ```
 
 Version 2.0.0+ is compatible with Scala 2.13, 2.12, and 2.11.
@@ -52,7 +52,7 @@ The `Collection213Upgrade` rewrite upgrades to the 2.13 collections without the 
 
 ```scala
 // build.sbt
-scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.3"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.4"
 addCompilerPlugin(scalafixSemanticdb)
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```
@@ -71,8 +71,8 @@ To cross-build for 2.12 and 2.11, the rewrite rule introduces a dependency on th
 
 ```scala
 // build.sbt
-scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.3"
-libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3"
+scalafixDependencies in ThisBuild += "org.scala-lang.modules" %% "scala-collection-migrations" % "2.1.4"
+libraryDependencies +=  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4"
 addCompilerPlugin(scalafixSemanticdb)
 scalacOptions ++= List("-Yrangepos", "-P:semanticdb:synthetics:on")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -14,13 +14,7 @@ lazy val commonSettings = Seq(
                                                  |See the NOTICE file distributed with this work for
                                                  |additional information regarding copyright ownership.
                                                  |""".stripMargin)),
-  scalaModuleMimaPreviousVersion := {
-    // We need to create a release version first to use MiMa
-    if(sys.env.get("SCALAJS_VERSION").exists(_.startsWith("1.0.0")))
-      None
-    else
-      Some("2.1.3")
-  }
+  scalaModuleMimaPreviousVersion := Some("2.1.4")
 )
 
 lazy val root = project


### PR DESCRIPTION
Update README and MiMa to refer to version 2.1.4 instead of 2.1.3, now that 2.1.4 is published.