### PR TITLE
Update sbt-scala-module to 2.1.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,6 @@ addSbtPlugin("org.scala-js"           % "sbt-scalajs"                   % scalaJ
 addSbtPlugin("org.portable-scala"     % "sbt-scalajs-crossproject"      % crossVer)
 addSbtPlugin("org.scala-native"       % "sbt-scala-native"              % scalaNativeVersion)
 addSbtPlugin("org.portable-scala"     % "sbt-scala-native-crossproject" % crossVer)
-addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"              % "2.1.3")
+addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"              % "2.1.4")
 addSbtPlugin("ch.epfl.scala"          % "sbt-scalafix"                  % "0.9.11")
 addSbtPlugin("com.eed3si9n"           % "sbt-buildinfo"                 % "0.9.0")


### PR DESCRIPTION
This new version includes the travis job number in the sonatype repo
description, which ensures that travis jobs don't interfere by writing
to the same repo.

In particular, for 2.12.11, there are two travis jobs in this repo:
one for the migration rules, one for the compat library.

This is why the 2.12 release was missing last time:
https://contributors.scala-lang.org/t/this-is-not-the-release-announcement-of-scala-js-1-0-0/4021/9