### PR TITLE
Update URL for Scaladoc 2.13.2

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/annotation/nowarn.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/annotation/nowarn.scala
@@ -17,6 +17,6 @@ package scala.annotation
  * `@nowarn`.
  *
  * For documentation on how to use the annotation in 2.13 see
- * https://www.scala-lang.org/files/archive/api/2.13.2/scala/annotation/nowarn.html
+ * https://www.scala-lang.org/api/current/scala/annotation/nowarn.html
  */
 class nowarn(value: String = "") extends StaticAnnotation

--- a/compat/src/main/scala-2.11_2.12/scala/annotation/nowarn.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/annotation/nowarn.scala
@@ -17,6 +17,6 @@ package scala.annotation
  * `@nowarn`.
  *
  * For documentation on how to use the annotation in 2.13 see
- * https://www.scala-lang.org/api/2.13.2/scala/nowarn.html
+ * https://www.scala-lang.org/files/archive/api/2.13.2/scala/annotation/nowarn.html
  */
 class nowarn(value: String = "") extends StaticAnnotation


### PR DESCRIPTION
The original URL is a dead link.