### PR TITLE
use PackageShared to de-duplicate code

### DIFF
--- a/compat/src/main/scala-2.11/scala/collection/compat/package.scala
+++ b/compat/src/main/scala-2.11/scala/collection/compat/package.scala
@@ -41,9 +41,6 @@ package object compat extends compat.PackageShared {
     : TraversableLikeExtensionMethods[traversable.A, Repr] =
     new TraversableLikeExtensionMethods[traversable.A, Repr](traversable.conversion(self))
 
-  implicit def toSeqExtensionMethods[A](self: c.Seq[A]): SeqExtensionMethods[A] =
-    new SeqExtensionMethods[A](self)
-
   implicit def toTrulyTraversableLikeExtensionMethods[T1, El1, Repr1](self: T1)(
       implicit w1: T1 => TraversableLike[El1, Repr1]
   ): TrulyTraversableLikeExtensionMethods[El1, Repr1] =

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -184,6 +184,10 @@ private[compat] trait PackageShared {
   implicit def toMapViewExtensionMethods[K, V, C <: scala.collection.Map[K, V]](
       self: IterableView[(K, V), C]): MapViewExtensionMethods[K, V, C] =
     new MapViewExtensionMethods[K, V, C](self)
+
+  implicit def toSeqExtensionMethods[A](self: c.Seq[A]): SeqExtensionMethods[A] =
+    new SeqExtensionMethods[A](self)
+
 }
 
 class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {

--- a/compat/src/main/scala-2.12/scala/collection/compat/package.scala
+++ b/compat/src/main/scala-2.12/scala/collection/compat/package.scala
@@ -50,9 +50,6 @@ package object compat extends compat.PackageShared {
     : TraversableLikeExtensionMethods[traversable.A, Repr] =
     new TraversableLikeExtensionMethods[traversable.A, Repr](traversable.conversion(self))
 
-  implicit def toSeqExtensionMethods[A](self: c.Seq[A]): SeqExtensionMethods[A] =
-    new SeqExtensionMethods[A](self)
-
   implicit def toTrulyTraversableLikeExtensionMethods[T1, El1, Repr1](self: T1)(
       implicit w1: T1 => TraversableLike[El1, Repr1]
   ): TrulyTraversableLikeExtensionMethods[El1, Repr1] =


### PR DESCRIPTION
as per #367, we thought the duplication was necessary for binary
compatibility, but it isn't