### PR TITLE
Update for Scala Native 0.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ scala:
   - 3.0.0-M3
 
 env:
-  - SCALAJS_VERSION=       ADOPTOPENJDK=8
-  - SCALAJS_VERSION=1.4.0  ADOPTOPENJDK=8
-  - SCALAJS_VERSION=       ADOPTOPENJDK=11
-  - SCALAJS_VERSION=1.4.0  ADOPTOPENJDK=11
+  - SCALAJS_VERSION=          ADOPTOPENJDK=8
+  - SCALAJS_VERSION=1.4.0     ADOPTOPENJDK=8
+  - SCALANATIVE_VERSION=0.4.0 ADOPTOPENJDK=8 
+  - SCALAJS_VERSION=          ADOPTOPENJDK=11
+  - SCALAJS_VERSION=1.4.0     ADOPTOPENJDK=11
+  - SCALANATIVE_VERSION=0.4.0 ADOPTOPENJDK=11
 
 matrix:
 
@@ -22,28 +24,24 @@ matrix:
 
     # run migration test
     - scala: 2.12.12
-      env: TEST_SCALAFIX=true           ADOPTOPENJDK=8
+      env: TEST_SCALAFIX=true      ADOPTOPENJDK=8
 
     # run binary compatibility test
     - scala: 2.12.12
-      env: TEST_BINARY_COMPAT=true      ADOPTOPENJDK=8
+      env: TEST_BINARY_COMPAT=true ADOPTOPENJDK=8
 
     # run scalafmt
     - scala: 2.12.12
-      env: TEST_SCALAFMT=true           ADOPTOPENJDK=8
+      env: TEST_SCALAFMT=true      ADOPTOPENJDK=8
 
-    # Scala Native includes
-    - scala: 2.11.12
-      env: SCALANATIVE_VERSION=0.3.9    ADOPTOPENJDK=8
+  exclude:
 
-    - scala: 2.11.12
-      env: SCALANATIVE_VERSION=0.4.0-M2 ADOPTOPENJDK=8
+    # not supported yet
+    - scala: 3.0.0-M3
+      env: SCALANATIVE_VERSION=0.4.0 ADOPTOPENJDK=8
 
-    - scala: 2.11.12
-      env: SCALANATIVE_VERSION=0.3.9    ADOPTOPENJDK=11
-
-    - scala: 2.11.12
-      env: SCALANATIVE_VERSION=0.4.0-M2 ADOPTOPENJDK=11
+    - scala: 3.0.0-M3
+      env: SCALANATIVE_VERSION=0.4.0 ADOPTOPENJDK=11
 
 install:
   - git fetch --tags # get all tags for sbt-dynver

--- a/build.sbt
+++ b/build.sbt
@@ -100,9 +100,9 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform, NativePlatform
     .nativeSettings(
       nativeLinkStubs := true,
       addCompilerPlugin(
-        "org.scala-native" % "junit-plugin" % "0.4.0-SNAPSHOT" cross CrossVersion.full
+        "org.scala-native" % "junit-plugin" % "0.4.0" cross CrossVersion.full
       ),
-      libraryDependencies += "org.scala-native" %%% "junit-runtime" % "0.4.0-SNAPSHOT",
+      libraryDependencies += "org.scala-native" %%% "junit-runtime" % "0.4.0",
       Test / fork := false // Scala Native cannot run forked tests
     )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,10 @@ lazy val root = project
     compat211Native,
     compat212JVM,
     compat212JS,
+    compat212Native,
     compat213JVM,
     compat213JS,
+    compat213Native,
     compat30JVM,
     compat30JS,
     `scalafix-data211`,
@@ -96,10 +98,12 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform, NativePlatform
     .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
     .disablePlugins(ScalafixPlugin)
     .nativeSettings(
-      crossScalaVersions := List(scala211),
-      scalaVersion := scala211, // allows to compile if scalaVersion set not 2.11
       nativeLinkStubs := true,
-      Test / test := {}
+      addCompilerPlugin(
+        "org.scala-native" % "junit-plugin" % "0.4.0-SNAPSHOT" cross CrossVersion.full
+      ),
+      libraryDependencies += "org.scala-native" %%% "junit-runtime" % "0.4.0-SNAPSHOT",
+      Test / fork := false // Scala Native cannot run forked tests
     )
 )
 
@@ -113,8 +117,10 @@ lazy val compat211JS     = compat211.js
 lazy val compat211Native = compat211.native
 lazy val compat212JVM    = compat212.jvm
 lazy val compat212JS     = compat212.js
+lazy val compat212Native = compat212.native
 lazy val compat213JVM    = compat213.jvm
 lazy val compat213JS     = compat213.js
+lazy val compat213Native = compat213.native
 lazy val compat30JVM     = compat30.jvm
 lazy val compat30JS      = compat30.js
 
@@ -353,7 +359,7 @@ inThisBuild(
 
           Seq(
             List(s"$projectPrefix/clean"),
-            if (isScalaNative) List() else List(s"$testProjectPrefix/test"),
+            List(s"$testProjectPrefix/test"),
             List(s"$projectPrefix/publishLocal"),
             publishTask
           ).flatten

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val root = project
 lazy val junit = libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
 
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.12"
+lazy val scala212 = "2.12.13"
 lazy val scala213 = "2.13.4"
 lazy val scala30  = "3.0.0-M3"
 
@@ -100,9 +100,9 @@ lazy val compat = MultiScalaCrossProject(JSPlatform, JVMPlatform, NativePlatform
     .nativeSettings(
       nativeLinkStubs := true,
       addCompilerPlugin(
-        "org.scala-native" % "junit-plugin" % "0.4.0" cross CrossVersion.full
+        "org.scala-native" % "junit-plugin" % nativeVersion cross CrossVersion.full
       ),
-      libraryDependencies += "org.scala-native" %%% "junit-runtime" % "0.4.0",
+      libraryDependencies += "org.scala-native" %%% "junit-runtime" % nativeVersion,
       Test / fork := false // Scala Native cannot run forked tests
     )
 )

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -5,6 +5,7 @@ import sbtcrossproject.{Platform, CrossProject}
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 import sbtcrossproject.CrossPlugin.autoImport._
 import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
+import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport._
 
 import java.io.File
 
@@ -87,6 +88,7 @@ class MultiScalaCrossProject(platforms: Seq[Platform],
         .settings(moduleName := name)
         .jvmSettings(scalaVersion := scalaV)
         .jsSettings(scalaVersion := scalaVJs)
+        .nativeSettings(scalaVersion := scalaV)
         .settings(srcFull(name))
 
     configurePerScala(configure(resultingProject))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ val crossVer = "1.0.0"
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.4.0")
 val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).filter(_.nonEmpty).getOrElse("0.3.9")
+  Option(System.getenv("SCALANATIVE_VERSION")).filter(_.nonEmpty).getOrElse("0.4.0")
 
 addSbtPlugin("ch.epfl.lamp"           % "sbt-dotty"                     % "0.5.1")
 addSbtPlugin("org.scala-js"           % "sbt-scalajs"                   % scalaJSVersion)


### PR DESCRIPTION
Trying to get a little jump on this. Works locally with two Scala Native tests failing on Scala `2.11-2.13`. Was able to test `ekrich/sconfig` against the locally built version and that worked fine.

For CI

- Not sure if Scala Native SNAPSHOT will resolve 
- Not sure about the `.travis.yml` update