### PR TITLE
avoid using type parameters on Left or Right

### DIFF
--- a/compat/src/test/scala/test/scala/collection/BuildFromTest.scala
+++ b/compat/src/test/scala/test/scala/collection/BuildFromTest.scala
@@ -141,8 +141,10 @@ class BuildFromTest {
     val xs4: List[Int]    = xs2
     val xs5: List[String] = xs3
 
-    val xs6                         = TreeMap((1, "1"), (2, "2"))
-    val (xs7, xs8)                  = mapSplit(xs6) { case (k, v) => Left[(String, Int), (Int, Boolean)]((v, k)) }
+    val xs6 = TreeMap((1, "1"), (2, "2"))
+    val (xs7, xs8) = mapSplit(xs6) {
+      case (k, v) => Left((v, k)): Either[(String, Int), (Int, Boolean)]
+    }
     val xs9: TreeMap[String, Int]   = xs7
     val xs10: TreeMap[Int, Boolean] = xs8
   }


### PR DESCRIPTION
this future-proofs the code for scala/scala#9303, and IMO the new code is just as good anyway

the code could be even better with `withRight` (we wouldn't need to repeat `(String, Int)`), but we don't have `withRight` in 2.11/2.12

as for the reformatting, well, scalafmt insisted