### PR TITLE
Update Scala 2.12 to minimum Scala Native supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: scala
 
 scala:
   - 2.11.12
-  - 2.12.12
+  - 2.12.13
   - 2.13.4
   - 3.0.0-M3
 
@@ -23,15 +23,15 @@ matrix:
   include:
 
     # run migration test
-    - scala: 2.12.12
+    - scala: 2.12.13
       env: TEST_SCALAFIX=true      ADOPTOPENJDK=8
 
     # run binary compatibility test
-    - scala: 2.12.12
+    - scala: 2.12.13
       env: TEST_BINARY_COMPAT=true ADOPTOPENJDK=8
 
     # run scalafmt
-    - scala: 2.12.12
+    - scala: 2.12.13
       env: TEST_SCALAFMT=true      ADOPTOPENJDK=8
 
   exclude:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ And, it includes support for some non-collections classes such as the `@nowarn` 
 
 ## Migration rules
 
-The migration rules use scalafix. Please see the [official installation instructions](https://scalacenter.github.io/scalafix/docs/users/installation.html) and, in particular, check that your full Scala version is supported (ex 2.12.12).
+The migration rules use scalafix. Please see the [official installation instructions](https://scalacenter.github.io/scalafix/docs/users/installation.html) and, in particular, check that your full Scala version is supported (ex 2.12.13).
 
 ```scala
 // project/plugins.sbt

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -23,7 +23,7 @@ import java.io.File
  *
  * // instanciate a sbt project
  * lazy val myProject211 = myProject("2.11.12", _.settings(...) /* scala version dependent configurations */)
- * lazy val myProject212 = myProject("2.12.12" , _.settings(...))
+ * lazy val myProject212 = myProject("2.12.13" , _.settings(...))
  * // ...
  * }}}
  */


### PR DESCRIPTION
`compat212Native / update` is failing before this change because the `nscplugin` and `junit-plugin` are not published for Scala `2.12.12`