### PR TITLE
Deprecate update method on i.ArraySeq impls

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -115,13 +115,21 @@ object ArraySeq {
         ArrayBuilder.make[T]()(m) mapResult ArraySeq.unsafeWrapArray[T]
     }
 
+  private def unsupportedUpdate: Nothing =
+    throw new UnsupportedOperationException("immutable ArraySeq does not support mutation")
+
+  private final val updateDeprecationMsg =
+    "Mutation is not supported for immutable ArraySeq, and should not have ever been " +
+      "part of the API"
+
   @SerialVersionUID(3L)
   final class ofRef[T <: AnyRef](val unsafeArray: Array[T]) extends ArraySeq[T] with Serializable {
     lazy val elemTag         = ClassTag[T](unsafeArray.getClass.getComponentType)
     def length: Int          = unsafeArray.length
     def apply(index: Int): T = unsafeArray(index)
-    def update(index: Int, elem: T) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: T): Unit = unsupportedUpdate
+    override def hashCode                 = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofRef[_] =>
         arrayEquals(unsafeArray.asInstanceOf[Array[AnyRef]],
@@ -135,8 +143,9 @@ object ArraySeq {
     def elemTag                 = ClassTag.Byte
     def length: Int             = unsafeArray.length
     def apply(index: Int): Byte = unsafeArray(index)
-    def update(index: Int, elem: Byte) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Byte): Unit = unsupportedUpdate
+    override def hashCode                    = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -148,8 +157,9 @@ object ArraySeq {
     def elemTag                  = ClassTag.Short
     def length: Int              = unsafeArray.length
     def apply(index: Int): Short = unsafeArray(index)
-    def update(index: Int, elem: Short) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Short): Unit = unsupportedUpdate
+    override def hashCode                     = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _             => super.equals(that)
@@ -161,8 +171,9 @@ object ArraySeq {
     def elemTag                 = ClassTag.Char
     def length: Int             = unsafeArray.length
     def apply(index: Int): Char = unsafeArray(index)
-    def update(index: Int, elem: Char) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Char): Unit = unsupportedUpdate
+    override def hashCode                    = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -174,8 +185,9 @@ object ArraySeq {
     def elemTag                = ClassTag.Int
     def length: Int            = unsafeArray.length
     def apply(index: Int): Int = unsafeArray(index)
-    def update(index: Int, elem: Int) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Int): Unit = unsupportedUpdate
+    override def hashCode                   = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _           => super.equals(that)
@@ -187,8 +199,9 @@ object ArraySeq {
     def elemTag                 = ClassTag.Long
     def length: Int             = unsafeArray.length
     def apply(index: Int): Long = unsafeArray(index)
-    def update(index: Int, elem: Long) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Long): Unit = unsupportedUpdate
+    override def hashCode                    = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _            => super.equals(that)
@@ -200,8 +213,9 @@ object ArraySeq {
     def elemTag                  = ClassTag.Float
     def length: Int              = unsafeArray.length
     def apply(index: Int): Float = unsafeArray(index)
-    def update(index: Int, elem: Float) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Float): Unit = unsupportedUpdate
+    override def hashCode                     = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
       case _             => super.equals(that)
@@ -213,8 +227,9 @@ object ArraySeq {
     def elemTag                   = ClassTag.Double
     def length: Int               = unsafeArray.length
     def apply(index: Int): Double = unsafeArray(index)
-    def update(index: Int, elem: Double) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Double): Unit = unsupportedUpdate
+    override def hashCode                      = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
       case _              => super.equals(that)
@@ -228,8 +243,9 @@ object ArraySeq {
     def elemTag                    = ClassTag.Boolean
     def length: Int                = unsafeArray.length
     def apply(index: Int): Boolean = unsafeArray(index)
-    def update(index: Int, elem: Boolean) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Boolean): Unit = unsupportedUpdate
+    override def hashCode                       = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _               => super.equals(that)
@@ -241,8 +257,9 @@ object ArraySeq {
     def elemTag                 = ClassTag.Unit
     def length: Int             = unsafeArray.length
     def apply(index: Int): Unit = unsafeArray(index)
-    def update(index: Int, elem: Unit) { unsafeArray(index) = elem }
-    override def hashCode = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
+    @deprecated(updateDeprecationMsg, since = "2.4.2")
+    def update(index: Int, elem: Unit): Unit = unsupportedUpdate
+    override def hashCode                    = MurmurHash3.arrayHash(unsafeArray, MurmurHash3.seqSeed)
     override def equals(that: Any) = that match {
       case that: ofUnit => unsafeArray.length == that.unsafeArray.length
       case _            => super.equals(that)


### PR DESCRIPTION
Deprecate `update` method on `i.ArraySeq` implementations,
and change the implementations of the method to throw
an `UnsupportedOperationException`.

Fixes #419