### PR TITLE
fix formatting to satisfy scalafmt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,9 +119,9 @@ lazy val compat = new MultiScalaCrossProject(
       "org.scala-native" % "junit-plugin" % nativeVersion cross CrossVersion.full
     ),
     mimaPreviousArtifacts := (CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((3, 1)) => mimaPreviousArtifacts.value.filter(_.revision != "2.6.0")
-        case _ => mimaPreviousArtifacts.value
-      }),
+      case Some((3, 1)) => mimaPreviousArtifacts.value.filter(_.revision != "2.6.0")
+      case _            => mimaPreviousArtifacts.value
+    }),
     libraryDependencies += "org.scala-native" %%% "junit-runtime" % nativeVersion,
     Test / fork := false // Scala Native cannot run forked tests
   )


### PR DESCRIPTION
The formatting check failed at https://github.com/scala/scala-collection-compat/pull/524 and I'm not sure why I didn't notice. I normally would fix something like this before merging a PR. 🤷 