### PR TITLE
Add Iterator.nextOption

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -348,6 +348,9 @@ class IteratorExtensionMethods[A](private val self: c.Iterator[A]) extends AnyVa
   def sameElements[B >: A](that: c.TraversableOnce[B]): Boolean = {
     self.sameElements(that.iterator)
   }
+  def nextOption(): Option[A] = {
+    if (self.hasNext) Some(self.next()) else None
+  }
   def concat[B >: A](that: c.TraversableOnce[B]): c.TraversableOnce[B] = self ++ that
   def tapEach[U](f: A => U): c.Iterator[A]                             = self.map(a => { f(a); a })
 }

--- a/compat/src/test/scala/test/scala/collection/CollectionTest.scala
+++ b/compat/src/test/scala/test/scala/collection/CollectionTest.scala
@@ -115,6 +115,14 @@ class CollectionTest {
   }
 
   @Test
+  def nextOption(): Unit = {
+    val it = Iterator(1, 2)
+    assertEquals(Some(1), it.nextOption())
+    assertEquals(Some(2), it.nextOption())
+    assertEquals(None, it.nextOption())
+  }
+
+  @Test
   def tapEach(): Unit = {
     var count = 0
     val it    = Iterator(1, 2, 3).tapEach(count += _)


### PR DESCRIPTION
Implementation adapted from scala-2.13 sources. Couldn't find any existing tests for it, so added a basic unit test.