### PR TITLE
sbt 1.7.0-RC2 (was 1.6.2)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.0-RC2


### PR DESCRIPTION
it's perhaps slightly unusual to adopt an RC in a scala/* repo, but I think enough of us have had enough experience with 1.7 for it to be safe. I want to take advantage of the new support for not repeating Scala version numbers in the Actions config.

besides, dogfooding/testing 1.7 is good.