### PR TITLE
GitHub Actions config: avoid duplicating Scala version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.12, 2.12.15, 2.13.8, 3.0.2]
+        scala: [2.11.x, 2.12.x, 2.13.x, 3.0.x]
         platform: [jvm, js, native]
         mode: [normal]
         exclude:
-          - scala: 3.0.2
+          - scala: 3.0.x
             platform: native
           - java: 11
             platform: js
@@ -27,27 +27,27 @@ jobs:
             platform: native
         include:
           - java: 8
-            scala: 2.12.15
+            scala: 2.12.x
             mode: testScalafix
             platform: jvm
           - java: 8
-            scala: 2.12.15
+            scala: 2.12.x
             mode: testBinaryCompat
             platform: jvm
           - java: 8
-            scala: 2.12.15
+            scala: 2.12.x
             mode: testScalafmt
             platform: jvm
           - java: 8
-            scala: 2.12.15
+            scala: 2.12.x
             mode: headerCheck
             platform: jvm
           - java: 11
-            scala: 2.12.15
+            scala: 2.12.x
             mode: normal
             platform: jvm
           - java: 17
-            scala: 2.12.15
+            scala: 2.12.x
             mode: normal
             platform: jvm
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -372,7 +372,7 @@ inThisBuild {
 
           val platformSuffix = if (isScalaJs) "JS" else if (isScalaNative) "Native" else ""
 
-          val compatProject       = "compat" + ciScalaVersion.get.binary + platformSuffix
+          val compatProject       = s"compat${ciScalaVersion.get}$platformSuffix"
           val binaryCompatProject = "binaryCompat"
 
           val testProjectPrefix =
@@ -394,7 +394,7 @@ inThisBuild {
             }
 
           Seq(
-            List(s"""++${sys.env.get("CI_SCALA_VERSION").get}!"""),
+            List(s"""++${sys.env.get("CI_SCALA_VERSION").get}"""),
             List(s"$projectPrefix/clean"),
             List(s"$testProjectPrefix/test"),
             List(s"$projectPrefix/publishLocal"),

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,24 +1,24 @@
-case class Version(major: Int, minor: Int, patch: Int) {
-  def binary: String            = s"${major}${minor}"
-  override def toString: String = s"${major}.${minor}.${patch}"
+case class Version(major: Int, minor: Int) {
+  override def toString = s"${major}${minor}"
 }
 
 object Version {
-  // the (#.+)? part allows republishing for a new Scala version
-  private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)(?:#.+)?".r
-  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+)-(.+)(?:#.+)?".r
+  // `(#.+)?` allows republishing for a new Scala version
+  // `|x` allows the sbt 1.7 style ".x" versions
+  private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+|x)(?:#.+)?".r
+  private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+|x)-(.+)(?:#.+)?".r
   private val versionRegex2 = "([0-9]+)\\.([0-9]+)(?:#.+)?".r
   private val versionRegex3 = "([0-9]+)(?:#.+)?".r
   def parse(raw: String): Option[Version] = {
     raw match {
-      case versionRegex0(major, minor, patch) =>
-        Some(Version(major.toInt, minor.toInt, patch.toInt))
-      case versionRegex1(major, minor, patch, _) =>
-        Some(Version(major.toInt, minor.toInt, patch.toInt))
+      case versionRegex0(major, minor, _) =>
+        Some(Version(major.toInt, minor.toInt))
+      case versionRegex1(major, minor, _, _) =>
+        Some(Version(major.toInt, minor.toInt))
       case versionRegex2(major, minor) =>
-        Some(Version(major.toInt, minor.toInt, 0))
+        Some(Version(major.toInt, minor.toInt))
       case versionRegex3(major) =>
-        Some(Version(major.toInt, 0, 0))
+        Some(Version(major.toInt, 0))
       case _ =>
         None
     }


### PR DESCRIPTION
by using new sbt 1.7 feature