### PR TITLE
for Scala 3 users, require Scala 3.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,45 +11,43 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.x, 2.12.x, 2.13.x, 3.0.x]
-        platform: [jvm, js, native]
+        scala: [2.11.x, 2.12.x, 2.13.x, 3.x]
+        platform: [JVM, JS, Native]
         mode: [normal]
         exclude:
-          - scala: 3.0.x
-            platform: native
           - java: 11
-            platform: js
+            platform: JS
           - java: 11
-            platform: native
+            platform: Native
           - java: 17
-            platform: js
+            platform: JS
           - java: 17
-            platform: native
+            platform: Native
         include:
           - java: 8
             scala: 2.12.x
             mode: testScalafix
-            platform: jvm
+            platform: JVM
           - java: 8
             scala: 2.12.x
             mode: testBinaryCompat
-            platform: jvm
+            platform: JVM
           - java: 8
             scala: 2.12.x
             mode: testScalafmt
-            platform: jvm
+            platform: JVM
           - java: 8
             scala: 2.12.x
             mode: headerCheck
-            platform: jvm
+            platform: JVM
           - java: 11
             scala: 2.12.x
             mode: normal
-            platform: jvm
+            platform: JVM
           - java: 17
             scala: 2.12.x
             mode: normal
-            platform: jvm
+            platform: JVM
     runs-on: ubuntu-latest
     env:
       CI_JDK: ${{matrix.java}}

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,9 @@ lazy val root = project
     compat213JVM,
     compat213JS,
     compat213Native,
-    compat30JVM,
-    compat30JS,
-    compat31Native,
+    compat3JVM,
+    compat3JS,
+    compat3Native,
     scalafixData211,
     scalafixData212,
     scalafixData213,
@@ -53,8 +53,7 @@ lazy val junit = libraryDependencies += "com.github.sbt" % "junit-interface" % "
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.15"
 lazy val scala213 = "2.13.8"
-lazy val scala30  = "3.0.2"
-lazy val scala31  = "3.1.3"
+lazy val scala3   = "3.1.3"
 
 lazy val compat = new MultiScalaCrossProject(
   "compat",
@@ -158,8 +157,7 @@ lazy val compat = new MultiScalaCrossProject(
 val compat211 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala211)
 val compat212 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala212)
 val compat213 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala213)
-val compat30  = compat(Seq(JSPlatform, JVMPlatform), scala30)
-val compat31  = compat(Seq(JVMPlatform, NativePlatform), scala31)
+val compat3   = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala3)
 
 lazy val compat211JVM    = compat211.jvm
 lazy val compat211JS     = compat211.js
@@ -170,9 +168,9 @@ lazy val compat212Native = compat212.native
 lazy val compat213JVM    = compat213.jvm
 lazy val compat213JS     = compat213.js
 lazy val compat213Native = compat213.native
-lazy val compat30JVM     = compat30.jvm
-lazy val compat30JS      = compat30.js
-lazy val compat31Native  = compat31.native
+lazy val compat3JVM      = compat3.jvm
+lazy val compat3JS       = compat3.js
+lazy val compat3Native   = compat3.native
 
 lazy val binaryCompatOld = project
   .in(file("binary-compat/old"))
@@ -335,8 +333,7 @@ lazy val scalafixTests = project
   .enablePlugins(BuildInfoPlugin, ScalafixTestkitPlugin)
 
 val ciScalaVersion = sys.env.get("CI_SCALA_VERSION").flatMap(Version.parse)
-val isScalaJs      = sys.env.get("CI_PLATFORM") == Some("js")
-val isScalaNative  = sys.env.get("CI_PLATFORM") == Some("native")
+val ciPlatform     = sys.env.get("CI_PLATFORM").map(p => if (p == "JVM") "" else p)
 val isScalafix     = sys.env.get("CI_MODE") == Some("testScalafix")
 val isScalafmt     = sys.env.get("CI_MODE") == Some("testScalafmt")
 val isBinaryCompat = sys.env.get("CI_MODE") == Some("testBinaryCompat")
@@ -370,9 +367,7 @@ inThisBuild {
           ).foreach(k =>
             println(k.padTo(20, " ").mkString("") + " -> " + sys.env.getOrElse(k, "None")))
 
-          val platformSuffix = if (isScalaJs) "JS" else if (isScalaNative) "Native" else ""
-
-          val compatProject       = s"compat${ciScalaVersion.get}$platformSuffix"
+          val compatProject       = s"compat${ciScalaVersion.get}${ciPlatform.get}"
           val binaryCompatProject = "binaryCompat"
 
           val testProjectPrefix =

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -30,7 +30,10 @@ import java.io.File
 trait MultiScala {
   def majorMinor(in: String): String = {
     val Array(major, minor, _) = in.split("\\.")
-    major + minor
+    if (major == "2")
+      s"$major$minor"
+    else
+      major
   }
 
   def projectIdPerScala(name: String, scalaV: String): String = s"$name${majorMinor(scalaV)}"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,24 +1,19 @@
-case class Version(major: Int, minor: Int) {
-  override def toString = s"${major}${minor}"
-}
-
 object Version {
   // `(#.+)?` allows republishing for a new Scala version
   // `|x` allows the sbt 1.7 style ".x" versions
   private val versionRegex0 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+|x)(?:#.+)?".r
   private val versionRegex1 = "v?([0-9]+)\\.([0-9]+)\\.([0-9]+|x)-(.+)(?:#.+)?".r
-  private val versionRegex2 = "([0-9]+)\\.([0-9]+)(?:#.+)?".r
-  private val versionRegex3 = "([0-9]+)(?:#.+)?".r
-  def parse(raw: String): Option[Version] = {
+  private val versionRegex2 = "([0-9]+)\\.([0-9]+|x)(?:#.+)?".r
+  def parse(raw: String): Option[String] = {
     raw match {
       case versionRegex0(major, minor, _) =>
-        Some(Version(major.toInt, minor.toInt))
+        Some(s"${major.toInt}${minor.toInt}")
       case versionRegex1(major, minor, _, _) =>
-        Some(Version(major.toInt, minor.toInt))
+        Some(s"${major.toInt}${minor.toInt}")
+      case versionRegex2(major, "x") =>
+        Some(s"${major.toInt}")
       case versionRegex2(major, minor) =>
-        Some(Version(major.toInt, minor.toInt))
-      case versionRegex3(major) =>
-        Some(Version(major.toInt, 0))
+        Some(s"${major.toInt}${minor.toInt}")
       case _ =>
         None
     }


### PR DESCRIPTION
as per scala/scala-lang#1387, there's no longer any need to keep supporting Scala 3.0.x. it's fine to expect people to upgrade to 3.1 or higher

Admittedly I'm making a bit of an executive decision here. But I see this happening in many places in the ecosystem.

Also, it simplifies the build. Scala 3.0.x didn't support Scala Native, so we had to do weird stuff to publish for 3.0 on JS and JVM but 3.1 on Native. This removes those complications.