### PR TITLE
scalafix 0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The migration rules use scalafix. Please see the [official installation instruct
 
 ```scala
 // project/plugins.sbt
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 ```
 
 ### Collection213Upgrade

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,5 @@ addSbtPlugin("org.portable-scala"     % "sbt-scalajs-crossproject"      % "1.2.0
 addSbtPlugin("org.scala-native"       % "sbt-scala-native"              % "0.4.5")
 addSbtPlugin("org.portable-scala"     % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"              % "3.0.1")
-addSbtPlugin("ch.epfl.scala"          % "sbt-scalafix"                  % "0.9.34")
+addSbtPlugin("ch.epfl.scala"          % "sbt-scalafix"                  % "0.10.1")
 addSbtPlugin("com.eed3si9n"           % "sbt-buildinfo"                 % "0.11.0")


### PR DESCRIPTION
https://github.com/scalameta/scalameta/pull/2684, first released in scalameta 4.5.1 (scalafix 0.10.0), changed a behavior, so this takes a more intrusive but also more robust approach so that the rule works with scalafix 0.10.x.