### PR TITLE
Make ArraySeq extends IndexedSeqOptimized

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -15,7 +15,7 @@ package scala.collection.compat.immutable
 import java.util.Arrays
 
 import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.AbstractSeq
+import scala.collection.{AbstractSeq, IndexedSeqOptimized}
 import scala.collection.generic._
 import scala.collection.immutable.IndexedSeq
 import scala.collection.mutable.{ArrayBuilder, Builder, WrappedArrayBuilder}
@@ -34,7 +34,7 @@ import scala.util.hashing.MurmurHash3
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-abstract class ArraySeq[+T] extends AbstractSeq[T] with IndexedSeq[T] {
+abstract class ArraySeq[+T] extends AbstractSeq[T] with IndexedSeq[T] with IndexedSeqOptimized[T, ArraySeq[T]] {
 
   override protected[this] def thisCollection: ArraySeq[T] = this
 

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/immutable/ArraySeq.scala
@@ -34,7 +34,10 @@ import scala.util.hashing.MurmurHash3
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  */
-abstract class ArraySeq[+T] extends AbstractSeq[T] with IndexedSeq[T] with IndexedSeqOptimized[T, ArraySeq[T]] {
+abstract class ArraySeq[+T]
+    extends AbstractSeq[T]
+    with IndexedSeq[T]
+    with IndexedSeqOptimized[T, ArraySeq[T]] {
 
   override protected[this] def thisCollection: ArraySeq[T] = this
 

--- a/compat/src/test/scala/test/scala/collection/ArraySeqTest.scala
+++ b/compat/src/test/scala/test/scala/collection/ArraySeqTest.scala
@@ -72,4 +72,11 @@ class ArraySeqTest {
     Assert.assertEquals(ArraySeq[T](), array.slice(1, 1))
     Assert.assertEquals(ArraySeq[T](), array.slice(2, 1))
   }
+
+  @Test def ArraySeqIndexedSeqOptimized(): Unit = {
+    val x                = ArraySeq(1, 2)
+    val y                = ArraySeq(3, 4)
+    val z: ArraySeq[Int] = x ++ y
+    assert(z.toList == List(1, 2, 3, 4))
+  }
 }


### PR DESCRIPTION
Make `ArraySeq[T]` extends `IndexedSeqOptimized[T, ArraySeq[T]]` so that operation expecting `CanBuildFrom[ArraySeq[_], T, ArraySeq[T]]` return specialized `ArraySeq[T]` instead of `IndexedSeq[T]`.

Without this, the following can't compile
```scala
val x = ArraySeq(1, 2)
val y = ArraySeq(3, 4)
val z: ArraySeq[Int] = x ++ y
```