### PR TITLE
Upgrade Scala Native to 0.4.10 and drop Scala 2.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         platform: [JVM, JS, Native]
         mode: [normal]
         exclude:
+          - scala: 2.11.x
+            platform: Native
           - java: 11
             platform: JS
           - java: 11

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val root = project
   .aggregate(
     compat211JVM,
     compat211JS,
-    compat211Native,
     compat212JVM,
     compat212JS,
     compat212Native,
@@ -132,7 +131,6 @@ lazy val compat = new MultiScalaCrossProject(
     Test / fork := false // Scala.js cannot run forked tests
   ).jsEnablePlugins(ScalaJSJUnitPlugin),
   _.nativeSettings(
-    nativeLinkStubs := true,
     mimaPreviousArtifacts := (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, 1)) => mimaPreviousArtifacts.value.filter(_.revision != "2.6.0")
       case _            => mimaPreviousArtifacts.value
@@ -151,14 +149,13 @@ lazy val compat = new MultiScalaCrossProject(
   ).nativeEnablePlugins(ScalaNativeJUnitPlugin)
 )
 
-val compat211 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala211)
+val compat211 = compat(Seq(JSPlatform, JVMPlatform), scala211)
 val compat212 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala212)
 val compat213 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala213)
 val compat3   = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala3)
 
 lazy val compat211JVM    = compat211.jvm
 lazy val compat211JS     = compat211.js
-lazy val compat211Native = compat211.native
 lazy val compat212JVM    = compat212.jvm
 lazy val compat212JS     = compat212.js
 lazy val compat212Native = compat212.native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-js"           % "sbt-scalajs"                   % "1.12.0")
 addSbtPlugin("org.portable-scala"     % "sbt-scalajs-crossproject"      % "1.2.0")
-addSbtPlugin("org.scala-native"       % "sbt-scala-native"              % "0.4.9")
+addSbtPlugin("org.scala-native"       % "sbt-scala-native"              % "0.4.10")
 addSbtPlugin("org.portable-scala"     % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module"              % "3.0.1")
 addSbtPlugin("ch.epfl.scala"          % "sbt-scalafix"                  % "0.10.4")


### PR DESCRIPTION
As mentioned in https://github.com/scala/scala-collection-compat/pull/579, a minor version bump on release would be great.