### PR TITLE
Add `RegexOps`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val compat = new MultiScalaCrossProject(
             sharedSourceDir / "scala-2.11_2.12"
         }
       },
-      versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+      versionPolicyIntention := Compatibility.BinaryCompatible,
       mimaBinaryIssueFilters ++= {
         import com.typesafe.tools.mima.core._
         import com.typesafe.tools.mima.core.ProblemFilters._

--- a/compat/src/main/scala-2.11_2.12/scala/util/matching/compat/package.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/util/matching/compat/package.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.util.matching
+
+package object compat {
+  final implicit class RegexOps(val regex: Regex) extends AnyVal {
+
+    /** Returns whether this `Regex` matches the given character sequence.
+     *
+     * Like the extractor, this method takes anchoring into account.
+     *
+     * @param source The text to match against
+     * @return true if and only if `source` matches this `Regex`.
+     * @see [[Regex#unanchored]]
+     * @example {{{"""\d+""".r matches "123" // returns true}}}
+     */
+    def matches(source: CharSequence): Boolean = regex.pattern.matcher(source).matches()
+  }
+
+}

--- a/compat/src/main/scala-2.13/scala/util/matching/compat/package.scala
+++ b/compat/src/main/scala-2.13/scala/util/matching/compat/package.scala
@@ -1,0 +1,18 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.util.matching
+
+package object compat {
+  type Regex = scala.util.matching.Regex
+  val Regex = scala.util.matching.Regex
+}

--- a/compat/src/test/scala/scala/util/matching/compat/RegexOpsTest.scala
+++ b/compat/src/test/scala/scala/util/matching/compat/RegexOpsTest.scala
@@ -1,0 +1,26 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.util.matching.compat
+
+import org.junit.Assert._
+import org.junit.Test
+
+class RegexOpsTest {
+
+  @Test
+  def testMatches(): Unit = {
+    assertTrue(".*hello.*".r.matches("hey hello"))
+    assertFalse(".*hello.*".r.matches("hey hop"))
+  }
+
+}


### PR DESCRIPTION
Recently stumbled on the fact that `Regex#matches` doesn't exist in 2.12
i had to change `versionPolicyIntention` to `Compatibility.BinaryCompatible` to get tests green. Mima newbie here, so don't kick me too hard here.