### PR TITLE
use newer GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
       CI_MODE: ${{matrix.mode}}
       CI_PLATFORM: ${{matrix.platform}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: coursier/cache-action@v6
-    - uses: actions/setup-java@v2
+    - uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{matrix.java}}


### PR DESCRIPTION
'Node.js 12 actions are deprecated', GitHub was complaining
