### PR TITLE
Use Scaladex badge on ReadMe to show Scala version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![scala-collection-compat Scala version support](https://index.scala-lang.org/scala/scala-collection-compat/scala-collection-compat/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scala/scala-collection-compat/scala-collection-compat)
+
 ## Purpose and scope
 
 This library makes some Scala 2.13 APIs available on Scala 2.11 and 2.12.


### PR DESCRIPTION
This Scaladex badge summarises which versions of Scala are supported by `scala-collection-compat` (and what the latest `scala-collection-compat` version is for each of those Scala versions):

[![scala-collection-compat Scala version support](https://index.scala-lang.org/scala/scala-collection-compat/scala-collection-compat/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/scala/scala-collection-compat/scala-collection-compat)

More details on the badge format: scalacenter/scaladex#660