### PR TITLE
Upgrade to 0.5.0 and drop Scala 2.11 for Scala Native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
             platform: JS
           - java: 17
             platform: Native
+          - scala: 2.11.x
+            platform: Native
         include:
           - java: 8
             scala: 2.12.x

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,6 @@ lazy val root = project
   .aggregate(
     compat211JVM,
     compat211JS,
-    compat211Native,
     compat212JVM,
     compat212JS,
     compat212Native,
@@ -134,7 +133,6 @@ lazy val compat = new MultiScalaCrossProject(
     Test / fork := false // Scala.js cannot run forked tests
   ).jsEnablePlugins(ScalaJSJUnitPlugin),
   _.nativeSettings(
-    nativeLinkStubs := true,
     mimaPreviousArtifacts := (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, 1)) => mimaPreviousArtifacts.value.filter(_.revision != "2.6.0")
       case _ => mimaPreviousArtifacts.value
@@ -154,14 +152,13 @@ lazy val compat = new MultiScalaCrossProject(
   ).nativeEnablePlugins(ScalaNativeJUnitPlugin)
 )
 
-val compat211 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala211)
+val compat211 = compat(Seq(JSPlatform, JVMPlatform), scala211)
 val compat212 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala212)
 val compat213 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala213)
 val compat3 = compat(Seq(JSPlatform, JVMPlatform, NativePlatform), scala3)
 
 lazy val compat211JVM = compat211.jvm
 lazy val compat211JS = compat211.js
-lazy val compat211Native = compat211.native
 lazy val compat212JVM = compat212.jvm
 lazy val compat212JS = compat212.js
 lazy val compat212Native = compat212.native

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.0-RC2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "3.1.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.9")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.0-RC2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "3.1.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.4")


### PR DESCRIPTION
There is a level of consensus in the Scala Native community for dropping `0.4.x` when `0.5.0` final is released. This puts developers of libraries in a bit of an awkward situation which we understand. For perspective, we supported `0.3.x` along with `0.4.0-M2` for a long time and it was a bit of a pain for builds so this may be part of the current thinking. Also, this time around we have an active project whereas previously it was unknown when `0.4.0` final would occur.

- Adds Scala Native `0.5.0` and drops support for Scala 2.11.