### PR TITLE
Add Array.from extension for scala 2.11 and 2.12

### DIFF
--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -362,7 +362,10 @@ private[compat] trait PackageShared {
 
 class ArrayExtensions(private val fact: Array.type) extends AnyVal {
   def from[A: ClassTag](source: TraversableOnce[A]): Array[A] =
-    fact.apply(source.toSeq: _*)
+    source match {
+      case it: Iterable[A] => it.toArray[A]
+      case _ => source.toIterator.toArray[A]
+    }
 }
 
 class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -360,7 +360,7 @@ private[compat] trait PackageShared {
     new RandomExtensions(self)
 }
 
-class ArrayExtensions(private val fact: Array.type) extends AnyVal {
+final class ArrayExtensions(private val fact: Array.type) extends AnyVal {
   def from[A: ClassTag](source: TraversableOnce[A]): Array[A] =
     source match {
       case it: Iterable[A] => it.toArray[A]

--- a/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
+++ b/compat/src/main/scala-2.11_2.12/scala/collection/compat/PackageShared.scala
@@ -272,6 +272,9 @@ private[compat] trait PackageShared {
     builder.result()
   }
 
+  implicit def toArrayExtensions(fact: Array.type): ArrayExtensions =
+    new ArrayExtensions(fact)
+
   implicit def toImmutableSortedMapExtensions(
       fact: i.SortedMap.type): ImmutableSortedMapExtensions =
     new ImmutableSortedMapExtensions(fact)
@@ -355,6 +358,11 @@ private[compat] trait PackageShared {
 
   implicit def toRandomExtensions(self: Random): RandomExtensions =
     new RandomExtensions(self)
+}
+
+class ArrayExtensions(private val fact: Array.type) extends AnyVal {
+  def from[A: ClassTag](source: TraversableOnce[A]): Array[A] =
+    fact.apply(source.toSeq: _*)
 }
 
 class ImmutableSortedMapExtensions(private val fact: i.SortedMap.type) extends AnyVal {

--- a/compat/src/test/scala/test/scala/collection/CollectionTest.scala
+++ b/compat/src/test/scala/test/scala/collection/CollectionTest.scala
@@ -56,6 +56,9 @@ class CollectionTest {
   @Test
   def testFrom: Unit = {
     val xs = List(1, 2, 3)
+    val a = Array.from(xs)
+    val aT: Array[Int] = a
+    assertTrue(Array(1, 2, 3).sameElements(a))
     val v = Vector.from(xs)
     val vT: Vector[Int] = v
     assertEquals(Vector(1, 2, 3), v)


### PR DESCRIPTION
Without the extension, code fails to compile for scala 2.11 and 2.12 with
```
 value from is not a member of object Array
     val a = Array.from(xs)
``` 

Add missing extension to the compat package