### PR TITLE
adjust a test to pass on both 2.13.14 and 15

### DIFF
--- a/compat/src/test/scala/test/scala/collection/LazyListTest.scala
+++ b/compat/src/test/scala/test/scala/collection/LazyListTest.scala
@@ -381,7 +381,7 @@ class LazyListTest {
       try {
         finite.force
         fail("Expected RuntimeException to be thrown")
-      } catch { case e: RuntimeException => assertTrue(e.getMessage.contains("self-referential")) }
+      } catch { case e: RuntimeException => assertTrue(e.getMessage.contains("self-refer")) }
     }
     assertNoStackOverflow {
       class L { val ll: LazyList[Nothing] = LazyList.empty #::: ll }; (new L).ll


### PR DESCRIPTION
necessary because of scala/scala#10818

as caught by the Scala 2 community build