### PR TITLE
Scala 3.3.3, 2.13.13, 2.12.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,9 +50,9 @@ lazy val root = project
 lazy val junit = libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
 
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.17"
-lazy val scala213 = "2.13.11"
-lazy val scala3 = "3.2.2"
+lazy val scala212 = "2.12.19"
+lazy val scala213 = "2.13.13"
+lazy val scala3 = "3.3.3"
 
 lazy val compat = new MultiScalaCrossProject(
   "compat",


### PR DESCRIPTION
I didn't go to 2.13.14 because I'd have to upgrade Scala.js as well and we seek to avoid doing that in this repo unless we must, for maximum compatibility

going from Scala 3.2 to 3.3 might seem inconsistent with that, but I think we should do it, because all of the messaging around Scala 3 has been super consistent that 3.3 is the first LTS version and older versions are dead. besides, 3.3 isn't at all new anymore.