### PR TITLE
update `Using` from Scala 2.13.17 and add `UsingTest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,18 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 25]
-        scala: [2.11.x, 2.12.x, 2.13.x, 3.x]
+        scala: [2.12.x, 2.13.x, 3.x]
+        scala-js: [""]
         platform: [JVM, JS, Native]
         mode: [normal]
-        exclude:
-          - scala: 2.11.x
-            platform: Native
         include:
+          - java: 8
+            scala: 2.11.x
+            platform: JVM
+          - java: 8
+            scala: 2.11.x
+            platform: JS
+            scala-js: 1.12.0
           - java: 8
             scala: 2.12.x
             mode: testScalafix
@@ -38,6 +43,7 @@ jobs:
     env:
       CI_JDK: ${{matrix.java}}
       CI_SCALA_VERSION: ${{matrix.scala}}
+      CI_SCALAJS_VERSION: ${{matrix.scala-js}}
       CI_MODE: ${{matrix.mode}}
       CI_PLATFORM: ${{matrix.platform}}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,19 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 17]
+        java: [8, 25]
         scala: [2.11.x, 2.12.x, 2.13.x, 3.x]
         platform: [JVM, JS, Native]
         mode: [normal]
         exclude:
-          - java: 11
-            platform: JS
-          - java: 11
-            platform: Native
-          - java: 17
-            platform: JS
-          - java: 17
-            platform: Native
           - scala: 2.11.x
             platform: Native
         include:
@@ -41,14 +33,6 @@ jobs:
           - java: 8
             scala: 2.12.x
             mode: headerCheck
-            platform: JVM
-          - java: 11
-            scala: 2.12.x
-            mode: normal
-            platform: JVM
-          - java: 17
-            scala: 2.12.x
-            mode: normal
             platform: JVM
     runs-on: ubuntu-latest
     env:

--- a/build.sbt
+++ b/build.sbt
@@ -50,8 +50,8 @@ lazy val root = project
 lazy val junit = libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test
 
 lazy val scala211 = "2.11.12"
-lazy val scala212 = "2.12.19"
-lazy val scala213 = "2.13.13"
+lazy val scala212 = "2.12.20"
+lazy val scala213 = "2.13.17"
 lazy val scala3 = "3.3.6"
 
 lazy val compat = new MultiScalaCrossProject(
@@ -63,6 +63,16 @@ lazy val compat = new MultiScalaCrossProject(
       moduleName := "scala-collection-compat",
       scalaModuleAutomaticModuleName := Some("scala.collection.compat"),
       scalacOptions ++= Seq("-feature", "-language:higherKinds", "-language:implicitConversions"),
+      // we need to force Scala 3 to use the latest Scala 2 stdlib, otherwise
+      // we might get test failures if there are behavior changes in latest Scala 2 stdlib
+      dependencyOverrides ++= {
+        CrossVersion.partialVersion(scalaVersion.value) match {
+          case Some((3, _)) =>
+            Seq("org.scala-lang" % "scala-library" % scala213)
+          case _ =>
+            Seq()
+        }
+      },
       Compile / unmanagedSourceDirectories += {
         val sharedSourceDir = (ThisBuild / baseDirectory).value / "compat/src/main"
         CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -369,6 +369,7 @@ inThisBuild {
         else {
           List(
             "CI_SCALA_VERSION",
+            "CI_SCALAJS_VERSION",
             "CI_PLATFORM",
             "CI_MODE",
             "CI_JDK",

--- a/compat/src/main/scala-2.11/scala/util/Using.scala
+++ b/compat/src/main/scala-2.11/scala/util/Using.scala
@@ -16,132 +16,165 @@ import scala.io.Source
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** A utility for performing automatic resource management. It can be used to perform an
- * operation using resources, after which it releases the resources in reverse order
- * of their creation.
- *
- * ==Usage==
- *
- * There are multiple ways to automatically manage resources with `Using`. If you only need
- * to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
- * resource opening, operation, and resource releasing in a `Try`.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.{Try, Using}
- *
- * val lines: Try[Seq[String]] =
- *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
- *   }
- * }}}
- *
- * If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
- * be used. It allows the managing of arbitrarily many resources, whose creation, use, and
- * release are all wrapped in a `Try`.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.{Try, Using}
- *
- * val lines: Try[Seq[String]] = Using.Manager { use =>
- *   val r1 = use(new BufferedReader(new FileReader("file1.txt")))
- *   val r2 = use(new BufferedReader(new FileReader("file2.txt")))
- *   val r3 = use(new BufferedReader(new FileReader("file3.txt")))
- *   val r4 = use(new BufferedReader(new FileReader("file4.txt")))
- *
- *   // use your resources here
- *   def lines(reader: BufferedReader): Iterator[String] =
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
- *
- *   (lines(r1) ++ lines(r2) ++ lines(r3) ++ lines(r4)).toList
- * }
- * }}}
- *
- * If you wish to avoid wrapping management and operations in a `Try`, you can use
- * [[Using.resource `Using.resource`]], which throws any exceptions that occur.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.Using
- *
- * val lines: Seq[String] =
- *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
- *   }
- * }}}
- *
- * ==Suppression Behavior==
- *
- * If two exceptions are thrown (e.g., by an operation and closing a resource),
- * one of them is re-thrown, and the other is
- * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
- * If the two exceptions are of different 'severities' (see below), the one of a higher
- * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
- * exception. If the two exceptions are of the same severity, the one thrown first is
- * re-thrown, and the one thrown second is added to it as a suppressed exception.
- * If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
- * if it does not support suppression (see
- * [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
- * an exception that would have been suppressed is instead discarded.
- *
- * Exceptions are ranked from highest to lowest severity as follows:
- *   - `java.lang.VirtualMachineError`
- *   - `java.lang.LinkageError`
- *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
- *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
- *   - `scala.util.control.ControlThrowable`
- *   - all other exceptions
- *
- * When more than two exceptions are thrown, the first two are combined and
- * re-thrown as described above, and each successive exception thrown is combined
- * as it is thrown.
- *
- * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
- *                             suppression behavior.
- */
+  * operation using resources, after which it releases the resources in reverse order
+  * of their creation.
+  *
+  * ==Usage==
+  *
+  * There are multiple ways to automatically manage resources with `Using`. If you only need
+  * to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
+  * resource opening, operation, and resource releasing in a `Try`.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.{Try, Using}
+  *
+  * val lines: Try[Seq[String]] =
+  *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+  *   }
+  * }}}
+  *
+  * If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
+  * be used. It allows the managing of arbitrarily many resources, whose creation, use, and
+  * release are all wrapped in a `Try`.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.{Try, Using}
+  *
+  * val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
+  * val lines: Try[Seq[String]] = Using.Manager { use =>
+  *   // acquire resources
+  *   def mkreader(filename: String) = use(new BufferedReader(new FileReader(filename)))
+  *
+  *   // use your resources here
+  *   def lines(reader: BufferedReader): Iterator[String] =
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
+  *
+  *   files.map(mkreader).flatMap(lines)
+  * }
+  * }}}
+  *
+  * Composed or "wrapped" resources may be acquired in order of construction,
+  * if "underlying" resources are not closed. Although redundant in this case,
+  * here is the previous example with a wrapped call to `use`:
+  * {{{
+  *   def mkreader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
+  * }}}
+  *
+  * Custom resources can be registered on construction by requiring an implicit `Manager`.
+  * This ensures they will be released even if composition fails:
+  * {{{
+  * import scala.util.Using
+  *
+  * case class X(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   override def close() = println(s"CLOSE $x")
+  *   mgr.acquire(this)
+  * }
+  * case class Y(y: String)(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   val xres = X(x)
+  *   override def close() = println(s"CLOSE $y")
+  *   // an error during construction releases previously acquired resources
+  *   require(y != null, "y is null")
+  *   mgr.acquire(this)
+  * }
+  *
+  * Using.Manager { implicit mgr =>
+  *   val y = Y("Y")("X")
+  *   println(s"USE $y")
+  * }
+  * println {
+  *   Using.Manager { implicit mgr =>
+  *     Y(null)("X")
+  *   }
+  * } // Failure(java.lang.IllegalArgumentException: requirement failed: y is null)
+  * }}}
+  *
+  * If you wish to avoid wrapping management and operations in a `Try`, you can use
+  * [[Using.resource `Using.resource`]], which throws any exceptions that occur.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.Using
+  *
+  * val lines: Seq[String] =
+  *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+  *   }
+  * }}}
+  *
+  * ==Suppression Behavior==
+  *
+  * If two exceptions are thrown (e.g., by an operation and closing a resource),
+  * one of them is re-thrown, and the other is
+  * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
+  * If the two exceptions are of different 'severities' (see below), the one of a higher
+  * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
+  * exception. If the two exceptions are of the same severity, the one thrown first is
+  * re-thrown, and the one thrown second is added to it as a suppressed exception.
+  * If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
+  * if it does not support suppression (see
+  * [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
+  * an exception that would have been suppressed is instead discarded.
+  *
+  * Exceptions are ranked from highest to lowest severity as follows:
+  *   - `java.lang.VirtualMachineError`
+  *   - `java.lang.LinkageError`
+  *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
+  *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
+  *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
+  *   - `scala.util.control.ControlThrowable`
+  *
+  * When more than two exceptions are thrown, the first two are combined and
+  * re-thrown as described above, and each successive exception thrown is combined
+  * as it is thrown.
+  *
+  * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
+  *                             suppression behavior.
+  */
 object Using {
 
   /** Performs an operation using a resource, and then releases the resource,
-   * even if the operation throws an exception.
-   *
-   * $suppressionBehavior
-   *
-   * @return a [[Try]] containing an exception if one or more were thrown,
-   *         or the result of the operation if no exceptions were thrown
-   */
-  def apply[R: Releasable, A](resource: => R)(f: R => A): Try[A] = Try {
-    Using.resource(resource)(f)
-  }
+    * even if the operation throws an exception.
+    *
+    * $suppressionBehavior
+    *
+    * @return a [[Try]] containing an exception if one or more were thrown,
+    *         or the result of the operation if no exceptions were thrown
+    */
+  def apply[R: Releasable, A](resource: => R)(f: R => A): Try[A] =
+    Try { Using.resource(resource)(f) }
 
   /** A resource manager.
-   *
-   * Resources can be registered with the manager by calling [[acquire `acquire`]];
-   * such resources will be released in reverse order of their acquisition
-   * when the manager is closed, regardless of any exceptions thrown
-   * during use.
-   *
-   * $suppressionBehavior
-   *
-   * @note It is recommended for API designers to require an implicit `Manager`
-   *       for the creation of custom resources, and to call `acquire` during those
-   *       resources' construction. Doing so guarantees that the resource ''must'' be
-   *       automatically managed, and makes it impossible to forget to do so.
-   *
-   *
-   *       Example:
-   *       {{{
-   *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
-   *         extends BufferedReader(new FileReader(file)) {
-   *
-   *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
-   *
-   *         manager.acquire(this)
-   *       }
-   *       }}}
-   */
+    *
+    * Resources can be registered with the manager by calling [[acquire `acquire`]];
+    * such resources will be released in reverse order of their acquisition
+    * when the manager is closed, regardless of any exceptions thrown
+    * during use.
+    *
+    * $suppressionBehavior
+    *
+    * @note It is recommended for API designers to require an implicit `Manager`
+    *       for the creation of custom resources, and to call `acquire` during those
+    *       resources' construction. Doing so guarantees that the resource ''must'' be
+    *       automatically managed, and makes it impossible to forget to do so.
+    *
+    *
+    *       Example:
+    *       {{{
+    *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
+    *         extends BufferedReader(new FileReader(file)) {
+    *
+    *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
+    *
+    *         manager.acquire(this)
+    *       }
+    *       }}}
+    */
   final class Manager private {
     import Manager._
 
@@ -149,17 +182,17 @@ object Using {
     private[this] var resources: List[Resource[_]] = Nil
 
     /** Registers the specified resource with this manager, so that
-     * the resource is released when the manager is closed, and then
-     * returns the (unmodified) resource.
-     */
+      * the resource is released when the manager is closed, and then
+      * returns the (unmodified) resource.
+      */
     def apply[R: Releasable](resource: R): R = {
       acquire(resource)
       resource
     }
 
     /** Registers the specified resource with this manager, so that
-     * the resource is released when the manager is closed.
-     */
+      * the resource is released when the manager is closed.
+      */
     def acquire[R: Releasable](resource: R): Unit = {
       if (resource == null) throw new NullPointerException("null resource")
       if (closed) throw new IllegalStateException("Manager has already been closed")
@@ -196,33 +229,33 @@ object Using {
   object Manager {
 
     /** Performs an operation using a `Manager`, then closes the `Manager`,
-     * releasing its resources (in reverse order of acquisition).
-     *
-     * Example:
-     * {{{
-     * val lines = Using.Manager { use =>
-     *   use(new BufferedReader(new FileReader("file.txt"))).lines()
-     * }
-     * }}}
-     *
-     * If using resources which require an implicit `Manager` as a parameter,
-     * this method should be invoked with an `implicit` modifier before the function
-     * parameter:
-     *
-     * Example:
-     * {{{
-     * val lines = Using.Manager { implicit use =>
-     *   new SafeFileReader("file.txt").lines()
-     * }
-     * }}}
-     *
-     * See the main doc for [[Using `Using`]] for full details of suppression behavior.
-     *
-     * @param op the operation to perform using the manager
-     * @tparam A the return type of the operation
-     * @return a [[Try]] containing an exception if one or more were thrown,
-     *         or the result of the operation if no exceptions were thrown
-     */
+      * releasing its resources (in reverse order of acquisition).
+      *
+      * Example:
+      * {{{
+      * val lines = Using.Manager { use =>
+      *   use(new BufferedReader(new FileReader("file.txt"))).lines()
+      * }
+      * }}}
+      *
+      * If using resources which require an implicit `Manager` as a parameter,
+      * this method should be invoked with an `implicit` modifier before the function
+      * parameter:
+      *
+      * Example:
+      * {{{
+      * val lines = Using.Manager { implicit use =>
+      *   new SafeFileReader("file.txt").lines()
+      * }
+      * }}}
+      *
+      * See the main doc for [[Using `Using`]] for full details of suppression behavior.
+      *
+      * @param op the operation to perform using the manager
+      * @tparam A the return type of the operation
+      * @return a [[Try]] containing an exception if one or more were thrown,
+      *         or the result of the operation if no exceptions were thrown
+      */
     def apply[A](op: Manager => A): Try[A] = Try { (new Manager).manage(op) }
 
     private final class Resource[R](resource: R)(implicit releasable: Releasable[R]) {
@@ -231,18 +264,17 @@ object Using {
   }
 
   private def preferentiallySuppress(primary: Throwable, secondary: Throwable): Throwable = {
+    @annotation.nowarn("cat=deprecation") // avoid warning on mention of ThreadDeath
     def score(t: Throwable): Int = t match {
       case _: VirtualMachineError => 4
       case _: LinkageError => 3
       case _: InterruptedException | _: ThreadDeath => 2
-      case _: ControlThrowable => 0
+      case _: ControlThrowable => -1 // below everything
       case e if !NonFatal(e) => 1 // in case this method gets out of sync with NonFatal
-      case _ => -1
+      case _ => 0
     }
-    // special-case `ControlThrowable`, which incorrectly suppresses exceptions
-    //   before 2.13
     @inline def suppress(t: Throwable, suppressed: Throwable): Throwable = {
-      if (!t.isInstanceOf[ControlThrowable]) t.addSuppressed(suppressed); t
+      t.addSuppressed(suppressed); t
     }
 
     if (score(secondary) > score(primary)) suppress(secondary, primary)
@@ -250,18 +282,18 @@ object Using {
   }
 
   /** Performs an operation using a resource, and then releases the resource,
-   * even if the operation throws an exception. This method behaves similarly
-   * to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource the resource
-   * @param body     the operation to perform with the resource
-   * @tparam R the type of the resource
-   * @tparam A the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resource throws
-   */
+    * even if the operation throws an exception. This method behaves similarly
+    * to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource the resource
+    * @param body     the operation to perform with the resource
+    * @tparam R the type of the resource
+    * @tparam A the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resource throws
+    */
   def resource[R, A](resource: R)(body: R => A)(implicit releasable: Releasable[R]): A = {
     if (resource == null) throw new NullPointerException("null resource")
 
@@ -276,28 +308,27 @@ object Using {
       if (toThrow eq null) releasable.release(resource)
       else {
         try releasable.release(resource)
-        catch {
-          case other: Throwable => toThrow = preferentiallySuppress(toThrow, other)
-        } finally throw toThrow
+        catch { case other: Throwable => toThrow = preferentiallySuppress(toThrow, other) }
+        finally throw toThrow
       }
     }
   }
 
   /** Performs an operation using two resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, A](
       resource1: R1,
       resource2: => R2
@@ -309,22 +340,22 @@ object Using {
     }
 
   /** Performs an operation using three resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param resource3 the third resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam R3 the type of the third resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param resource3 the third resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam R3 the type of the third resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -339,24 +370,24 @@ object Using {
     }
 
   /** Performs an operation using four resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param resource3 the third resource
-   * @param resource4 the fourth resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam R3 the type of the third resource
-   * @tparam R4 the type of the fourth resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param resource3 the third resource
+    * @param resource4 the fourth resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam R3 the type of the third resource
+    * @tparam R4 the type of the fourth resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, R4: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -373,20 +404,20 @@ object Using {
       }
     }
 
-  /** A typeclass describing how to release a particular type of resource.
-   *
-   * A resource is anything which needs to be released, closed, or otherwise cleaned up
-   * in some way after it is finished being used, and for which waiting for the object's
-   * garbage collection to be cleaned up would be unacceptable. For example, an instance of
-   * [[java.io.OutputStream]] would be considered a resource, because it is important to close
-   * the stream after it is finished being used.
-   *
-   * An instance of `Releasable` is needed in order to automatically manage a resource
-   * with [[Using `Using`]]. An implicit instance is provided for all types extending
-   * [[java.lang.AutoCloseable]].
-   *
-   * @tparam R the type of the resource
-   */
+  /** A type class describing how to release a particular type of resource.
+    *
+    * A resource is anything which needs to be released, closed, or otherwise cleaned up
+    * in some way after it is finished being used, and for which waiting for the object's
+    * garbage collection to be cleaned up would be unacceptable. For example, an instance of
+    * [[java.io.OutputStream]] would be considered a resource, because it is important to close
+    * the stream after it is finished being used.
+    *
+    * An instance of `Releasable` is needed in order to automatically manage a resource
+    * with [[Using `Using`]]. An implicit instance is provided for all types extending
+    * [[java.lang.AutoCloseable]].
+    *
+    * @tparam R the type of the resource
+    */
   trait Releasable[-R] {
 
     /** Releases the specified resource. */
@@ -394,7 +425,8 @@ object Using {
   }
 
   object Releasable {
-
+    // prefer explicit types 2.14
+    // implicit val AutoCloseableIsReleasable: Releasable[AutoCloseable] = new Releasable[AutoCloseable] {}
     /** An implicit `Releasable` for [[java.lang.AutoCloseable `AutoCloseable`s]]. */
     implicit object AutoCloseableIsReleasable extends Releasable[AutoCloseable] {
       def release(resource: AutoCloseable): Unit = resource.close()

--- a/compat/src/main/scala-2.12/scala/util/Using.scala
+++ b/compat/src/main/scala-2.12/scala/util/Using.scala
@@ -15,132 +15,165 @@ package scala.util
 import scala.util.control.{ControlThrowable, NonFatal}
 
 /** A utility for performing automatic resource management. It can be used to perform an
- * operation using resources, after which it releases the resources in reverse order
- * of their creation.
- *
- * ==Usage==
- *
- * There are multiple ways to automatically manage resources with `Using`. If you only need
- * to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
- * resource opening, operation, and resource releasing in a `Try`.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.{Try, Using}
- *
- * val lines: Try[Seq[String]] =
- *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
- *   }
- * }}}
- *
- * If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
- * be used. It allows the managing of arbitrarily many resources, whose creation, use, and
- * release are all wrapped in a `Try`.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.{Try, Using}
- *
- * val lines: Try[Seq[String]] = Using.Manager { use =>
- *   val r1 = use(new BufferedReader(new FileReader("file1.txt")))
- *   val r2 = use(new BufferedReader(new FileReader("file2.txt")))
- *   val r3 = use(new BufferedReader(new FileReader("file3.txt")))
- *   val r4 = use(new BufferedReader(new FileReader("file4.txt")))
- *
- *   // use your resources here
- *   def lines(reader: BufferedReader): Iterator[String] =
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
- *
- *   (lines(r1) ++ lines(r2) ++ lines(r3) ++ lines(r4)).toList
- * }
- * }}}
- *
- * If you wish to avoid wrapping management and operations in a `Try`, you can use
- * [[Using.resource `Using.resource`]], which throws any exceptions that occur.
- *
- * Example:
- * {{{
- * import java.io.{BufferedReader, FileReader}
- * import scala.util.Using
- *
- * val lines: Seq[String] =
- *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
- *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
- *   }
- * }}}
- *
- * ==Suppression Behavior==
- *
- * If two exceptions are thrown (e.g., by an operation and closing a resource),
- * one of them is re-thrown, and the other is
- * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
- * If the two exceptions are of different 'severities' (see below), the one of a higher
- * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
- * exception. If the two exceptions are of the same severity, the one thrown first is
- * re-thrown, and the one thrown second is added to it as a suppressed exception.
- * If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
- * if it does not support suppression (see
- * [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
- * an exception that would have been suppressed is instead discarded.
- *
- * Exceptions are ranked from highest to lowest severity as follows:
- *   - `java.lang.VirtualMachineError`
- *   - `java.lang.LinkageError`
- *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
- *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
- *   - `scala.util.control.ControlThrowable`
- *   - all other exceptions
- *
- * When more than two exceptions are thrown, the first two are combined and
- * re-thrown as described above, and each successive exception thrown is combined
- * as it is thrown.
- *
- * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
- *                             suppression behavior.
- */
+  * operation using resources, after which it releases the resources in reverse order
+  * of their creation.
+  *
+  * ==Usage==
+  *
+  * There are multiple ways to automatically manage resources with `Using`. If you only need
+  * to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
+  * resource opening, operation, and resource releasing in a `Try`.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.{Try, Using}
+  *
+  * val lines: Try[Seq[String]] =
+  *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+  *   }
+  * }}}
+  *
+  * If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
+  * be used. It allows the managing of arbitrarily many resources, whose creation, use, and
+  * release are all wrapped in a `Try`.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.{Try, Using}
+  *
+  * val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
+  * val lines: Try[Seq[String]] = Using.Manager { use =>
+  *   // acquire resources
+  *   def mkreader(filename: String) = use(new BufferedReader(new FileReader(filename)))
+  *
+  *   // use your resources here
+  *   def lines(reader: BufferedReader): Iterator[String] =
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
+  *
+  *   files.map(mkreader).flatMap(lines)
+  * }
+  * }}}
+  *
+  * Composed or "wrapped" resources may be acquired in order of construction,
+  * if "underlying" resources are not closed. Although redundant in this case,
+  * here is the previous example with a wrapped call to `use`:
+  * {{{
+  *   def mkreader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
+  * }}}
+  *
+  * Custom resources can be registered on construction by requiring an implicit `Manager`.
+  * This ensures they will be released even if composition fails:
+  * {{{
+  * import scala.util.Using
+  *
+  * case class X(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   override def close() = println(s"CLOSE $x")
+  *   mgr.acquire(this)
+  * }
+  * case class Y(y: String)(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+  *   val xres = X(x)
+  *   override def close() = println(s"CLOSE $y")
+  *   // an error during construction releases previously acquired resources
+  *   require(y != null, "y is null")
+  *   mgr.acquire(this)
+  * }
+  *
+  * Using.Manager { implicit mgr =>
+  *   val y = Y("Y")("X")
+  *   println(s"USE $y")
+  * }
+  * println {
+  *   Using.Manager { implicit mgr =>
+  *     Y(null)("X")
+  *   }
+  * } // Failure(java.lang.IllegalArgumentException: requirement failed: y is null)
+  * }}}
+  *
+  * If you wish to avoid wrapping management and operations in a `Try`, you can use
+  * [[Using.resource `Using.resource`]], which throws any exceptions that occur.
+  *
+  * Example:
+  * {{{
+  * import java.io.{BufferedReader, FileReader}
+  * import scala.util.Using
+  *
+  * val lines: Seq[String] =
+  *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
+  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+  *   }
+  * }}}
+  *
+  * ==Suppression Behavior==
+  *
+  * If two exceptions are thrown (e.g., by an operation and closing a resource),
+  * one of them is re-thrown, and the other is
+  * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
+  * If the two exceptions are of different 'severities' (see below), the one of a higher
+  * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
+  * exception. If the two exceptions are of the same severity, the one thrown first is
+  * re-thrown, and the one thrown second is added to it as a suppressed exception.
+  * If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
+  * if it does not support suppression (see
+  * [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
+  * an exception that would have been suppressed is instead discarded.
+  *
+  * Exceptions are ranked from highest to lowest severity as follows:
+  *   - `java.lang.VirtualMachineError`
+  *   - `java.lang.LinkageError`
+  *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
+  *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
+  *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
+  *   - `scala.util.control.ControlThrowable`
+  *
+  * When more than two exceptions are thrown, the first two are combined and
+  * re-thrown as described above, and each successive exception thrown is combined
+  * as it is thrown.
+  *
+  * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
+  *                             suppression behavior.
+  */
 object Using {
 
   /** Performs an operation using a resource, and then releases the resource,
-   * even if the operation throws an exception.
-   *
-   * $suppressionBehavior
-   *
-   * @return a [[Try]] containing an exception if one or more were thrown,
-   *         or the result of the operation if no exceptions were thrown
-   */
-  def apply[R: Releasable, A](resource: => R)(f: R => A): Try[A] = Try {
-    Using.resource(resource)(f)
-  }
+    * even if the operation throws an exception.
+    *
+    * $suppressionBehavior
+    *
+    * @return a [[Try]] containing an exception if one or more were thrown,
+    *         or the result of the operation if no exceptions were thrown
+    */
+  def apply[R: Releasable, A](resource: => R)(f: R => A): Try[A] =
+    Try { Using.resource(resource)(f) }
 
   /** A resource manager.
-   *
-   * Resources can be registered with the manager by calling [[acquire `acquire`]];
-   * such resources will be released in reverse order of their acquisition
-   * when the manager is closed, regardless of any exceptions thrown
-   * during use.
-   *
-   * $suppressionBehavior
-   *
-   * @note It is recommended for API designers to require an implicit `Manager`
-   *       for the creation of custom resources, and to call `acquire` during those
-   *       resources' construction. Doing so guarantees that the resource ''must'' be
-   *       automatically managed, and makes it impossible to forget to do so.
-   *
-   *
-   *       Example:
-   *       {{{
-   *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
-   *         extends BufferedReader(new FileReader(file)) {
-   *
-   *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
-   *
-   *         manager.acquire(this)
-   *       }
-   *       }}}
-   */
+    *
+    * Resources can be registered with the manager by calling [[acquire `acquire`]];
+    * such resources will be released in reverse order of their acquisition
+    * when the manager is closed, regardless of any exceptions thrown
+    * during use.
+    *
+    * $suppressionBehavior
+    *
+    * @note It is recommended for API designers to require an implicit `Manager`
+    *       for the creation of custom resources, and to call `acquire` during those
+    *       resources' construction. Doing so guarantees that the resource ''must'' be
+    *       automatically managed, and makes it impossible to forget to do so.
+    *
+    *
+    *       Example:
+    *       {{{
+    *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
+    *         extends BufferedReader(new FileReader(file)) {
+    *
+    *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
+    *
+    *         manager.acquire(this)
+    *       }
+    *       }}}
+    */
   final class Manager private {
     import Manager._
 
@@ -148,17 +181,17 @@ object Using {
     private[this] var resources: List[Resource[_]] = Nil
 
     /** Registers the specified resource with this manager, so that
-     * the resource is released when the manager is closed, and then
-     * returns the (unmodified) resource.
-     */
+      * the resource is released when the manager is closed, and then
+      * returns the (unmodified) resource.
+      */
     def apply[R: Releasable](resource: R): R = {
       acquire(resource)
       resource
     }
 
     /** Registers the specified resource with this manager, so that
-     * the resource is released when the manager is closed.
-     */
+      * the resource is released when the manager is closed.
+      */
     def acquire[R: Releasable](resource: R): Unit = {
       if (resource == null) throw new NullPointerException("null resource")
       if (closed) throw new IllegalStateException("Manager has already been closed")
@@ -195,33 +228,33 @@ object Using {
   object Manager {
 
     /** Performs an operation using a `Manager`, then closes the `Manager`,
-     * releasing its resources (in reverse order of acquisition).
-     *
-     * Example:
-     * {{{
-     * val lines = Using.Manager { use =>
-     *   use(new BufferedReader(new FileReader("file.txt"))).lines()
-     * }
-     * }}}
-     *
-     * If using resources which require an implicit `Manager` as a parameter,
-     * this method should be invoked with an `implicit` modifier before the function
-     * parameter:
-     *
-     * Example:
-     * {{{
-     * val lines = Using.Manager { implicit use =>
-     *   new SafeFileReader("file.txt").lines()
-     * }
-     * }}}
-     *
-     * See the main doc for [[Using `Using`]] for full details of suppression behavior.
-     *
-     * @param op the operation to perform using the manager
-     * @tparam A the return type of the operation
-     * @return a [[Try]] containing an exception if one or more were thrown,
-     *         or the result of the operation if no exceptions were thrown
-     */
+      * releasing its resources (in reverse order of acquisition).
+      *
+      * Example:
+      * {{{
+      * val lines = Using.Manager { use =>
+      *   use(new BufferedReader(new FileReader("file.txt"))).lines()
+      * }
+      * }}}
+      *
+      * If using resources which require an implicit `Manager` as a parameter,
+      * this method should be invoked with an `implicit` modifier before the function
+      * parameter:
+      *
+      * Example:
+      * {{{
+      * val lines = Using.Manager { implicit use =>
+      *   new SafeFileReader("file.txt").lines()
+      * }
+      * }}}
+      *
+      * See the main doc for [[Using `Using`]] for full details of suppression behavior.
+      *
+      * @param op the operation to perform using the manager
+      * @tparam A the return type of the operation
+      * @return a [[Try]] containing an exception if one or more were thrown,
+      *         or the result of the operation if no exceptions were thrown
+      */
     def apply[A](op: Manager => A): Try[A] = Try { (new Manager).manage(op) }
 
     private final class Resource[R](resource: R)(implicit releasable: Releasable[R]) {
@@ -230,18 +263,17 @@ object Using {
   }
 
   private def preferentiallySuppress(primary: Throwable, secondary: Throwable): Throwable = {
+    @annotation.nowarn("cat=deprecation") // avoid warning on mention of ThreadDeath
     def score(t: Throwable): Int = t match {
       case _: VirtualMachineError => 4
       case _: LinkageError => 3
       case _: InterruptedException | _: ThreadDeath => 2
-      case _: ControlThrowable => 0
+      case _: ControlThrowable => -1 // below everything
       case e if !NonFatal(e) => 1 // in case this method gets out of sync with NonFatal
-      case _ => -1
+      case _ => 0
     }
-    // special-case `ControlThrowable`, which incorrectly suppresses exceptions
-    //   before 2.13
     @inline def suppress(t: Throwable, suppressed: Throwable): Throwable = {
-      if (!t.isInstanceOf[ControlThrowable]) t.addSuppressed(suppressed); t
+      t.addSuppressed(suppressed); t
     }
 
     if (score(secondary) > score(primary)) suppress(secondary, primary)
@@ -249,18 +281,18 @@ object Using {
   }
 
   /** Performs an operation using a resource, and then releases the resource,
-   * even if the operation throws an exception. This method behaves similarly
-   * to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource the resource
-   * @param body     the operation to perform with the resource
-   * @tparam R the type of the resource
-   * @tparam A the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resource throws
-   */
+    * even if the operation throws an exception. This method behaves similarly
+    * to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource the resource
+    * @param body     the operation to perform with the resource
+    * @tparam R the type of the resource
+    * @tparam A the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resource throws
+    */
   def resource[R, A](resource: R)(body: R => A)(implicit releasable: Releasable[R]): A = {
     if (resource == null) throw new NullPointerException("null resource")
 
@@ -275,28 +307,27 @@ object Using {
       if (toThrow eq null) releasable.release(resource)
       else {
         try releasable.release(resource)
-        catch {
-          case other: Throwable => toThrow = preferentiallySuppress(toThrow, other)
-        } finally throw toThrow
+        catch { case other: Throwable => toThrow = preferentiallySuppress(toThrow, other) }
+        finally throw toThrow
       }
     }
   }
 
   /** Performs an operation using two resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, A](
       resource1: R1,
       resource2: => R2
@@ -308,22 +339,22 @@ object Using {
     }
 
   /** Performs an operation using three resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param resource3 the third resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam R3 the type of the third resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param resource3 the third resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam R3 the type of the third resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -338,24 +369,24 @@ object Using {
     }
 
   /** Performs an operation using four resources, and then releases the resources
-   * in reverse order, even if the operation throws an exception. This method
-   * behaves similarly to Java's try-with-resources.
-   *
-   * $suppressionBehavior
-   *
-   * @param resource1 the first resource
-   * @param resource2 the second resource
-   * @param resource3 the third resource
-   * @param resource4 the fourth resource
-   * @param body      the operation to perform using the resources
-   * @tparam R1 the type of the first resource
-   * @tparam R2 the type of the second resource
-   * @tparam R3 the type of the third resource
-   * @tparam R4 the type of the fourth resource
-   * @tparam A  the return type of the operation
-   * @return the result of the operation, if neither the operation nor
-   *         releasing the resources throws
-   */
+    * in reverse order, even if the operation throws an exception. This method
+    * behaves similarly to Java's try-with-resources.
+    *
+    * $suppressionBehavior
+    *
+    * @param resource1 the first resource
+    * @param resource2 the second resource
+    * @param resource3 the third resource
+    * @param resource4 the fourth resource
+    * @param body      the operation to perform using the resources
+    * @tparam R1 the type of the first resource
+    * @tparam R2 the type of the second resource
+    * @tparam R3 the type of the third resource
+    * @tparam R4 the type of the fourth resource
+    * @tparam A  the return type of the operation
+    * @return the result of the operation, if neither the operation nor
+    *         releasing the resources throws
+    */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, R4: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -372,20 +403,20 @@ object Using {
       }
     }
 
-  /** A typeclass describing how to release a particular type of resource.
-   *
-   * A resource is anything which needs to be released, closed, or otherwise cleaned up
-   * in some way after it is finished being used, and for which waiting for the object's
-   * garbage collection to be cleaned up would be unacceptable. For example, an instance of
-   * [[java.io.OutputStream]] would be considered a resource, because it is important to close
-   * the stream after it is finished being used.
-   *
-   * An instance of `Releasable` is needed in order to automatically manage a resource
-   * with [[Using `Using`]]. An implicit instance is provided for all types extending
-   * [[java.lang.AutoCloseable]].
-   *
-   * @tparam R the type of the resource
-   */
+  /** A type class describing how to release a particular type of resource.
+    *
+    * A resource is anything which needs to be released, closed, or otherwise cleaned up
+    * in some way after it is finished being used, and for which waiting for the object's
+    * garbage collection to be cleaned up would be unacceptable. For example, an instance of
+    * [[java.io.OutputStream]] would be considered a resource, because it is important to close
+    * the stream after it is finished being used.
+    *
+    * An instance of `Releasable` is needed in order to automatically manage a resource
+    * with [[Using `Using`]]. An implicit instance is provided for all types extending
+    * [[java.lang.AutoCloseable]].
+    *
+    * @tparam R the type of the resource
+    */
   trait Releasable[-R] {
 
     /** Releases the specified resource. */
@@ -393,7 +424,8 @@ object Using {
   }
 
   object Releasable {
-
+    // prefer explicit types 2.14
+    // implicit val AutoCloseableIsReleasable: Releasable[AutoCloseable] = new Releasable[AutoCloseable] {}
     /** An implicit `Releasable` for [[java.lang.AutoCloseable `AutoCloseable`s]]. */
     implicit object AutoCloseableIsReleasable extends Releasable[AutoCloseable] {
       def release(resource: AutoCloseable): Unit = resource.close()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,7 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.1")
+val scalaJSVersion =
+  sys.env.get("CI_SCALAJS_VERSION").filter(_.nonEmpty).getOrElse("1.20.1")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.8")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")


### PR DESCRIPTION
ports https://github.com/scala/scala/pull/11000

fixes #692 

sequel to @NthPortal's #319

I was tempted to drop Scala 2.11, but in the end I was able to keep it in the build by special-casing it to use an older Scala.js version

I also had to do a bit of monkey business in the build for the tests to pass on Scala 3 even though Scala 3 hasn't taken the 2.13.17 upgrade yet. Once they take it, the monkey business can be removed and `UsingTest.scala` can be moved out of `src-jvm` and into `src` (since for some reason, the monkey business only worked on the JVM, not JS or Native).